### PR TITLE
fix: make supabase env variables optional for development

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,3 +1,4 @@
+import process from 'node:process'
 import { createLogger } from 'vite'
 
 export default defineNuxtConfig({
@@ -70,6 +71,8 @@ export default defineNuxtConfig({
       login: '/twitter-auth', // change with card page
       callback: '/confirm',
     },
+    url: process.env.SUPABASE_URL || 'https://placeholder.supabase.co',
+    key: process.env.SUPABASE_KEY || 'placeholder-key',
   },
 
   runtimeConfig: {


### PR DESCRIPTION
## Summary
Allows the development server to run without Supabase environment variables configured.

## Changes
- Added default placeholder values for `SUPABASE_URL` and `SUPABASE_KEY` in `nuxt.config.ts`
- Imported `process` from `node:process` to access environment variables
- Falls back to placeholder values when env variables are not set

## Benefits
- Developers can run the app in development mode without setting up Supabase
- No more startup crashes due to missing Supabase configuration
- Supabase features will use real values when env variables are provided