### PR TITLE
fix: filter to show only Polkadot wallets in wallet selection

### DIFF
--- a/app/components/wallet/connect/stage/wallet/WalletSelectionStage.client.vue
+++ b/app/components/wallet/connect/stage/wallet/WalletSelectionStage.client.vue
@@ -18,10 +18,10 @@ const {
 const activeTab = ref('All')
 
 const filteredInstalledWallets = computed(() => {
-  if (activeTab.value === 'All') {
-    return installedWallets.value
-  }
-  return installedWallets.value.filter(wallet => wallet.vm === ACTIVE_TAB_VM_MAP[activeTab.value])
+  // if (activeTab.value === 'All') {
+  //   return installedWallets.value
+  // }
+  return installedWallets.value.filter(wallet => wallet.vm === ACTIVE_TAB_VM_MAP.Polkadot)
 })
 
 async function processWalletExtensions(extensions: WalletExtension[], connectOnly: boolean): Promise<boolean> {
@@ -84,7 +84,7 @@ function onSelectUnistalledWallet(wallet: WalletExtension) {
 
 <template>
   <div class="space-y-6">
-    <WalletSelectionTabs v-model="activeTab" />
+    <!-- <WalletSelectionTabs v-model="activeTab" /> -->
 
     <InstalledWallets
       :extensions="filteredInstalledWallets"


### PR DESCRIPTION
Fixes #550

## Changes
- Updated wallet selection to filter and show only Polkadot (SUB) wallets
- Commented out 'All' tab functionality to enforce Polkadot-only filtering
- Removed the conditional check that would show all wallets

This ensures that only Polkadot-compatible wallets are displayed in the wallet selection interface.