### PR TITLE
fix: use accurate minted token count from blockchain for drops

### DIFF
--- a/app/components/drop/utils.ts
+++ b/app/components/drop/utils.ts
@@ -2,6 +2,7 @@ import type { DropItem } from '@/types'
 import { getDropById } from '@/services/fxart'
 import { fetchOdaCollection } from '@/services/oda'
 import { DropStatus } from '@/types'
+import { mintedTokens } from '~/utils/api/substrate.nft-pallets'
 
 export function formatCETDate(date: string, time: string): Date {
   return new Date(`${date}T${time}+02:00`)
@@ -64,14 +65,15 @@ export async function getEnrichedDrop(campaign: DropItem): Promise<DropItem | un
 
   // get some onchain data
   // ----------------------
-  const [{ supply, claimed: minted, metadata }, abi] = await Promise.all([
+  const [{ supply, claimed: minted, metadata }, totalMinted, abi] = await Promise.all([
     fetchOdaCollection(campaign.chain, address),
+    mintedTokens({ prefix: campaign.chain, collectionId: Number(address) }),
     Promise.resolve(null), // TODO: handle evm
   ])
 
   const onChainData = {
     max: Number(supply) || FALLBACK_DROP_COLLECTION_MAX,
-    minted: Number(minted),
+    minted: Number(totalMinted || minted),
     name: metadata?.name || '',
     collectionName: metadata?.name || '',
     collectionDescription: metadata?.description || '',

--- a/app/utils/api/substrate.nft-pallets.ts
+++ b/app/utils/api/substrate.nft-pallets.ts
@@ -44,6 +44,19 @@ export async function tokenEntries({ prefix, collectionId, max, excludeTokenId }
   return items
 }
 
+/**
+ * Get the number of minted tokens on a collection
+ * @param params - The parameters object
+ * @param params.prefix - The prefix of the chain
+ * @param params.collectionId - The ID of the collection
+ * @returns The number of minted tokens on the collection
+ */
+export async function mintedTokens({ prefix, collectionId }: { prefix: AssetHubChain, collectionId: number }) {
+  const api = getApi(prefix).api
+  const entries = await api.query.Nfts.Item.getEntries(collectionId)
+  return entries.length
+}
+
 export async function accountTokenEntries({ prefix, account, collectionId }: { prefix: AssetHubChain, account: string, collectionId: number }) {
   const api = getApi(prefix).api
   const entries = await api.query.Nfts.Account.getEntries(account)


### PR DESCRIPTION
Fixes #561

This PR improves the accuracy of the minted token count displayed for drops by fetching the actual count directly from the blockchain.

### Changes
- Added `mintedTokens()` function in `substrate.nft-pallets.ts` to query the blockchain for the actual number of minted tokens in a collection
- Updated `getEnrichedDrop()` to use the blockchain count as the primary source, falling back to the ODA claimed count if unavailable
- This ensures the minted count accurately reflects the on-chain state

### Why
The previous implementation relied on the ODA claimed count which could be out of sync with the actual blockchain state, leading to incorrect minted counts shown to users.