### PR TITLE
fix: The nfts list does not show up fully when scrolling to the bottom

### DIFF
--- a/app/composables/useInfiniteQuery.ts
+++ b/app/composables/useInfiniteQuery.ts
@@ -82,7 +82,7 @@ export function useInfiniteQuery<TData = any, TItem = any>(options: UseInfiniteQ
 
       totalCount.value = total
       currentOffset.value = offset + pageSize
-      hasMoreData.value = allItems.value.length < totalCount.value && newItems.length > 0
+      hasMoreData.value = newItems.length === pageSize
     }
     catch (error) {
       console.error('Error fetching data:', error)


### PR DESCRIPTION

closes #585

before:

<img width="2442" height="1642" alt="image" src="https://github.com/user-attachments/assets/c1444853-ec06-4d9d-8e77-31fb3b1f9b39" />



after fixing

<img width="2416" height="1616" alt="image" src="https://github.com/user-attachments/assets/1b6780f0-6253-4ec8-b0cc-d631eafce8f9" />
