### PR TITLE
refactor: migrate profile service to chaotic.art domain

### DIFF
--- a/app/services/profile.ts
+++ b/app/services/profile.ts
@@ -1,14 +1,9 @@
 import type { FetchError } from 'ofetch'
 import { encodeAddress, isEvmAddress } from 'dedot/utils'
 import { $fetch } from 'ofetch'
-import { isProduction } from '@/utils/env'
-
-const BASE_URL = isProduction
-  ? 'https://profile.kodadot.workers.dev/'
-  : 'https://profile-beta.kodadot.workers.dev/'
 
 const api = $fetch.create({
-  baseURL: BASE_URL,
+  baseURL: 'https://profile.chaotic.art',
 })
 
 export enum Socials {


### PR DESCRIPTION
Migrates the profile service from kodadot.workers.dev to profile.chaotic.art domain.

Changes:
- Removed environment-based URL logic (production/beta)
- Updated baseURL to use chaotic.art domain
- Simplified configuration by removing isProduction check

Closes #635