### PR TITLE
feat: migrate playground service URLs to chaotic.art domain

### DIFF
--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -17,11 +17,11 @@ export const URLS = {
     bucket: 'https://bucket.chaotic.art/',
     dyndata: 'https://dyndata.chaotic.art',
     oda: 'https://oda.chaotic.art',
+    playground: 'https://playground.chaotic.art',
+    playground_bucket: 'https://playground-bucket.chaotic.art',
 
     // TODO: migrate to chaotic
     nftStorage: 'https://ipos.kodadot.workers.dev/',
-    playground: 'https://playground.kodadot.workers.dev/',
-    playground_bucket: 'https://playground-r2.koda.art',
     cors_proxy: 'https://cors-proxy.kodadot.workers.dev/',
   },
   graphql: {


### PR DESCRIPTION
Migrates playground service URLs from kodadot.workers.dev/koda.art to chaotic.art domain.

### Changes
- Updated `playground` URL from `https://playground.kodadot.workers.dev/` to `https://playground.chaotic.art`
- Updated `playground_bucket` URL from `https://playground-r2.koda.art` to `https://playground-bucket.chaotic.art`

Closes #641