### PR TITLE
fix(create): provide chain context to success mint modal

### DIFF
--- a/app/components/common/successfulModal/SuccessfulModalBody.vue
+++ b/app/components/common/successfulModal/SuccessfulModalBody.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { ActionButton } from './ActionButtons.vue'
 import type { TransactionStatus } from '@/composables/useTransactionStatus'
+import type { SupportedChain } from '~/plugins/sdk.client'
 
 export interface ShareProp {
   disabled?: boolean
@@ -20,6 +21,7 @@ const props = defineProps<{
   txHash?: string
   share: ShareProp
   actionButtons: ActionButtonsProp
+  chain?: SupportedChain
 }>()
 
 function handleSecondaryActionClick() {
@@ -35,6 +37,7 @@ function handleSecondaryActionClick() {
       v-if="txHash"
       :tx-hash="txHash"
       :status="status"
+      :chain="chain"
     />
 
     <div class="mt-5">

--- a/app/components/common/successfulModal/TransactionSection.vue
+++ b/app/components/common/successfulModal/TransactionSection.vue
@@ -7,13 +7,14 @@ import { getSubscanExtrinsicUrl } from '~/utils/format/address'
 const props = defineProps<{
   txHash?: string
   status: TransactionStatus
+  chain?: SupportedChain
 }>()
 
 const { add: toast } = useToast()
 const { currentChain } = useChain()
 
 const txUrl = computed(() =>
-  getSubscanExtrinsicUrl(props.txHash || '', currentChain.value as SupportedChain),
+  getSubscanExtrinsicUrl(props.txHash || '', props.chain || currentChain.value as SupportedChain),
 )
 const { copy } = useClipboard({ source: txUrl })
 

--- a/app/components/create/modal/SuccessCollection.vue
+++ b/app/components/create/modal/SuccessCollection.vue
@@ -48,6 +48,7 @@ const modalData = computed(() => {
       collectionName: props.result?.name,
       metadata: props.result?.description,
     }],
+    chain: props.result.prefix,
   }
 })
 </script>
@@ -58,6 +59,7 @@ const modalData = computed(() => {
     :tx-hash="props.result?.hash"
     :share="modalData.share"
     :status="status"
+    :chain="modalData.chain"
     :action-buttons="modalData.actionButtons"
   >
     <SuccessfulItemsMedia

--- a/app/components/create/modal/SuccessNft.vue
+++ b/app/components/create/modal/SuccessNft.vue
@@ -47,6 +47,7 @@ const modalData = computed(() => {
       multiple: `You successfully created ${props.result.items.length} NFTs`,
     },
     items,
+    chain: props.result.prefix,
   }
 })
 </script>
@@ -56,6 +57,7 @@ const modalData = computed(() => {
     v-if="props.result?.type === 'nft'"
     :tx-hash="props.result?.hash"
     :share="modalData.share"
+    :chain="modalData.chain"
     :status="status"
     :action-buttons="modalData.actionButtons"
     :ui="{


### PR DESCRIPTION
## Issue 

created a nft using a non default chain (in this case assethub paseo) and tx url success modal had wrong subscan url

<img height="900" alt="CleanShot 2025-11-06 at 07 47 15@2x" src="https://github.com/user-attachments/assets/16bd704a-ac4e-4208-a3ab-d0db43fdc092" />

## solution

provide minting chain context to success modal tx result component

### nft

<img width="3240" height="2548" alt="CleanShot 2025-11-07 at 15 14 09@2x" src="https://github.com/user-attachments/assets/eaeea333-94bc-45de-9bfb-4bee5b886f23" />

### collection

<img width="2110" height="1972" alt="CleanShot 2025-11-07 at 15 11 58@2x" src="https://github.com/user-attachments/assets/cd9759d4-919b-49f7-a3fe-f2cc38fe9aa4" />
