### PR TITLE
fix: migrate cors-proxy URL to chaotic.art domain

### DIFF
--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -19,10 +19,10 @@ export const URLS = {
     oda: 'https://oda.chaotic.art',
     playground: 'https://playground.chaotic.art',
     playground_bucket: 'https://playground-bucket.chaotic.art',
+    cors_proxy: 'https://cors-proxy.chaotic.art',
 
     // TODO: migrate to chaotic
     nftStorage: 'https://ipos.kodadot.workers.dev/',
-    cors_proxy: 'https://cors-proxy.kodadot.workers.dev/',
   },
   graphql: {
     ahk: 'https://ahk.gql.api.kodadot.xyz/',


### PR DESCRIPTION
Migrates the cors-proxy service URL from the old domain to the new chaotic.art domain.

Closes #642

## Changes
- Updated `cors_proxy` URL in `app/utils/constants.ts` to use `https://cors-proxy.chaotic.art`

## Testing
- Verified URL constant is updated correctly
- Existing `getCorsProxiedUrl` function will automatically use the new endpoint