### PR TITLE
fix(wallet): account selected on copy address

### DIFF
--- a/app/components/wallet/connect/stage/account/WalletAccountListItem.vue
+++ b/app/components/wallet/connect/stage/account/WalletAccountListItem.vue
@@ -116,7 +116,7 @@ onMounted(async () => {
               color="neutral"
               variant="ghost"
               class="opacity-60 hover:opacity-100 transition-opacity"
-              @click.prevent="copyAddress(account.address)"
+              @click.stop="copyAddress(account.address)"
             />
           </div>
         </div>


### PR DESCRIPTION
### Issue 

Clicking on copy button would accidentally also select that account 

### Fixed
![CleanShot 2025-11-19 at 15 06 17](https://github.com/user-attachments/assets/d511be89-55f3-4ff4-b613-89c581a41d68)