### PR TITLE
fix: profile following modal size

### DIFF
--- a/app/components/profile/follow/ProfileFollowModal.vue
+++ b/app/components/profile/follow/ProfileFollowModal.vue
@@ -49,6 +49,9 @@ watchEffect(() => {
 <template>
   <UModal
     v-model:open="isOpen"
+    :ui="{
+      content: 'max-w-md w-full',
+    }"
   >
     <template #body>
       <div class="mb-6">


### PR DESCRIPTION
#### Issue 

modal had a lot of inner spacing, and its is bigger than it should be, looks out of place,  on koda it was compact

<img width="3402" height="2110" alt="CleanShot 2025-11-29 at 11 56 47@2x" src="https://github.com/user-attachments/assets/666b789f-e0ae-4c01-bb72-b1d9eadc1af2" />

### Solution 

make modal more compact, capping max size and removed extra padding

<img width="3412" height="2092" alt="CleanShot 2025-11-29 at 11 57 10@2x" src="https://github.com/user-attachments/assets/5dda7030-6865-4d85-aee3-5c01f6574c44" />
