### PR TITLE
fix: optimize NFT image loading with Cloudflare variants

### DIFF
--- a/app/components/common/card/TokenCard.client.vue
+++ b/app/components/common/card/TokenCard.client.vue
@@ -70,7 +70,7 @@ const route = useRoute()
 const { isCurrentAccount } = useAuth()
 const { artViewFilter } = storeToRefs(usePreferencesStore())
 
-const imageStatus = ref<'normal' | 'fallback'>('normal')
+const imageStatus = ref<'card' | 'normal' | 'fallback'>('card')
 const dataOwner = computed(() => owner.value || props.currentOwner)
 
 const isProfileRoute = computed(() => route.name?.toString().includes('chain-u-id'))
@@ -131,6 +131,18 @@ watchEffect(() => {
               @error="($event.target as HTMLAudioElement).style.display = 'none'"
             />
           </div>
+
+          <!-- Card Image -->
+          <!-- 1. Image from cloudflare image delivery -->
+          <!-- 2. Image from bucket.chaotic.art ipfs -->
+          <!-- 3. Image from collection metadata -->
+          <img
+            v-else-if="imageStatus === 'card' && (image || token?.metadata?.image)"
+            :src="ipfsToCfImageUrl(image || token?.metadata?.image, 'card')"
+            :alt="token?.metadata?.name || 'NFT'"
+            class="w-full h-full object-contain"
+            @error="imageStatus = 'normal'"
+          >
           <img
             v-else-if="imageStatus === 'normal' && (image || token?.metadata?.image)"
             :src="sanitizeIpfsUrl(image || token?.metadata?.image)"
@@ -144,6 +156,7 @@ watchEffect(() => {
             :alt="token?.metadata?.name || 'NFT'"
             class="w-full h-full object-contain"
           >
+
           <div
             v-else
             class="w-full h-full flex items-center justify-center bg-gray-100 dark:bg-neutral-700"

--- a/app/composables/useToken.ts
+++ b/app/composables/useToken.ts
@@ -48,6 +48,7 @@ export function useToken(props: {
   // Fetch data on component mount
   onMounted(async () => {
     try {
+      // fetch token data, collection data, and highest offer data
       const [tokenData, collectionData, highestOfferData] = await Promise.all([
         fetchOdaToken(props.chain, props.collectionId.toString(), props.tokenId.toString()).catch(() => null),
         fetchOdaCollection(props.chain, props.collectionId.toString()).catch(() => null),
@@ -61,6 +62,15 @@ export function useToken(props: {
       owner.value = token.value?.owner ?? null
       collectionCreator.value = collection.value?.owner ?? null
       queryPrice.value = token.value?.price ?? null
+
+      // fetch mime type for media
+      const media = token.value?.metadata?.animation_url || token.value?.metadata?.image || props.image
+      if (media) {
+        const [ok, _, mimeTypeData] = await t(fetchMimeType(media))
+        if (ok) {
+          mimeType.value = mimeTypeData.mime_type
+        }
+      }
 
       // fetch real-time price and owner
       const { api } = $sdk(props.chain)
@@ -97,14 +107,6 @@ export function useToken(props: {
           metadata_uri: collection.value?.metadata_uri ?? undefined,
           price: tokenData?.price ?? null,
           owner: tokenData?.owner ?? null,
-        }
-      }
-
-      const media = token.value?.metadata?.animation_url || token.value?.metadata?.image || props.image
-      if (media) {
-        const [ok, _, mimeTypeData] = await t(fetchMimeType(media))
-        if (ok) {
-          mimeType.value = mimeTypeData.mime_type
         }
       }
     }

--- a/app/utils/ipfs.ts
+++ b/app/utils/ipfs.ts
@@ -74,7 +74,7 @@ export function toOriginalContentUrl(baseurl: string) {
   return url.toString()
 }
 
-export function ipfsToCfImageUrl(ipfsUrl?: string, variant = 'public') {
+export function ipfsToCfImageUrl(ipfsUrl?: string, variant: 'public' | 'card' = 'public') {
   if (!ipfsUrl) {
     return ''
   }


### PR DESCRIPTION
## Summary

- Adds optimized image loading using Cloudflare Image Delivery 'card' variant for faster initial rendering
- Implements graceful fallback: CF optimized → IPFS original → collection metadata
- Moves mime type fetch earlier in the loading sequence for better UX

## Test plan

- [x] Verify NFT cards load faster on the explore page
- [x] Confirm fallback works when CF delivery fails
- [x] Check that high-resolution images are no longer loaded initially in card view

Closes #709