### PR TITLE
fix: resolve transition warning and profile navigation issues

### DIFF
--- a/app/components/common/ScrollToTop.client.vue
+++ b/app/components/common/ScrollToTop.client.vue
@@ -23,15 +23,16 @@ function scrollToTop() {
     leave-from-class="opacity-100 translate-y-0 scale-100"
     leave-to-class="opacity-0 translate-y-4 scale-95"
   >
-    <UButton
-      v-if="isVisible"
-      icon="i-heroicons-chevron-up"
-      color="primary"
-      variant="solid"
-      size="lg"
-      class="fixed w-10 h-10 bottom-6 right-6 z-50 rounded-full shadow-lg hover:shadow-xl transition-shadow duration-200 md:bottom-8 md:right-8"
-      aria-label="Scroll to top"
-      @click="scrollToTop"
-    />
+    <div v-if="isVisible" class="fixed bottom-6 right-6 z-50 md:bottom-8 md:right-8">
+      <UButton
+        icon="i-heroicons-chevron-up"
+        color="primary"
+        variant="solid"
+        size="lg"
+        class="w-10 h-10 rounded-full shadow-lg hover:shadow-xl transition-shadow duration-200"
+        aria-label="Scroll to top"
+        @click="scrollToTop"
+      />
+    </div>
   </Transition>
 </template>

--- a/app/components/profile/ProfileDetail.vue
+++ b/app/components/profile/ProfileDetail.vue
@@ -61,13 +61,31 @@ const tabsItems = ref([
   },
 ])
 
-const { data: followers, refresh: refreshFollowers } = useAsyncData(
-  `followersof${props.address}`,
-  () =>
-    fetchFollowersOf(props.address, {
-      limit: 3,
-    }),
-)
+const followers = ref<Awaited<ReturnType<typeof fetchFollowersOf>> | null>(null)
+const following = ref<Awaited<ReturnType<typeof fetchFollowing>> | null>(null)
+
+async function refreshFollowers() {
+  try {
+    followers.value = await fetchFollowersOf(props.address, { limit: 3 })
+  }
+  catch (error) {
+    console.error('Failed to fetch followers:', error)
+  }
+}
+
+async function refreshFollowing() {
+  try {
+    following.value = await fetchFollowing(props.address, { limit: 1 })
+  }
+  catch (error) {
+    console.error('Failed to fetch following:', error)
+  }
+}
+
+onMounted(() => {
+  refreshFollowers()
+  refreshFollowing()
+})
 
 const editProfileConfig: ButtonConfig = {
   label: 'Edit Existing Profile',
@@ -106,15 +124,10 @@ function onFollowingClick() {
   isFollowModalActive.value = true
 }
 
-const { data: following, refresh: refreshFollowing } = useAsyncData(
-  `following${props.address}`,
-  () => fetchFollowing(props.address, { limit: 1 }),
-)
-
-function refresh({ fetchFollowing = true } = {}) {
+function refresh({ fetchFollowing: shouldFetchFollowing = true } = {}) {
   refreshFollowers()
   refreshFollowing()
-  fetchFollowing && followButton.value?.refresh()
+  shouldFetchFollowing && followButton.value?.refresh()
 }
 const followersCount = computed(() => followers.value?.totalCount ?? 0)
 const followingCount = computed(() => following.value?.totalCount ?? 0)


### PR DESCRIPTION
## Summary
- Fix `<Transition> renders non-element root node that cannot be animated` warning by wrapping UButton in a div element and renaming ScrollToTop to `.client.vue`
- Fix unable to navigate to user profile from landing page artists list by replacing `useAsyncData` with manual fetching in `onMounted`

## Test plan
- [x] Navigate to landing page and verify artists list loads
- [x] Click on an artist from the list and verify profile page loads correctly
- [x] Scroll down on any page and verify scroll-to-top button appears without console warnings
- [x] Click scroll-to-top button and verify smooth scroll animation works