### PR TITLE
fix: Code-checker - Adjust the button with long zip file name

### DIFF
--- a/app/components/codeChecker/PreviewCard.vue
+++ b/app/components/codeChecker/PreviewCard.vue
@@ -3,7 +3,7 @@ import type { AssetMessage, Passed } from './types'
 import { useFullscreen } from '@vueuse/core'
 import config from './codechecker.config'
 import { downloadBase64Image } from './massPreview/utils'
-import { generateRandomHash } from './utils'
+import { generateRandomHash, prettifyZipFileName } from './utils'
 
 const props = defineProps<{
   selectedFile: File | null
@@ -271,7 +271,7 @@ watch(hash, emitHashUpdate)
           :disabled="!kodaRendererUsed"
           @click="exportAsPNG"
         >
-          <span>{{ `Export ${fileName} as PNG` }}</span>
+          <span>{{ `Export ${prettifyZipFileName(fileName)} as PNG` }}</span>
         </UButton>
         <USelectMenu
           :model-value="selectedVariation"

--- a/app/components/codeChecker/utils/index.ts
+++ b/app/components/codeChecker/utils/index.ts
@@ -183,3 +183,16 @@ export function getDocumentFromString(html: string): Document {
   const parser = new DOMParser()
   return parser.parseFromString(html, 'text/html')
 }
+
+export function prettifyZipFileName(name: string = ''): string {
+  const MAX_LENGTH = 18
+  if (name.length <= MAX_LENGTH) {
+    return name
+  }
+
+  const baseName = name.replace(/\.zip$/i, '')
+  const head = baseName.slice(0, 6)
+  const tail = baseName.slice(-6)
+
+  return `${head}...${tail}.zip`
+}


### PR DESCRIPTION
closes #732 

<img width="1050" height="442" alt="image" src="https://github.com/user-attachments/assets/40ef053d-b862-4e11-9dde-681d46d951c0" />
