### PR TITLE
chore: update GraphQL endpoints to Stellate CDN

### DIFF
--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -24,8 +24,8 @@ export const URLS = {
     nftStorage: 'https://ipos.chaotic.art',
   },
   graphql: {
-    ahk: 'https://ahk.gql.api.kodadot.xyz/',
-    ahp: 'https://ahp.gql.api.kodadot.xyz/',
+    ahk: 'https://chaotic-ahk.stellate.sh/',
+    ahp: 'https://chaotic-ahp.stellate.sh/',
   },
   providers: {
     coingecko: 'https://api.coingecko.com/api/v3',


### PR DESCRIPTION
## Summary

- Migrate `ahk` and `ahp` GraphQL API URLs from `kodadot.xyz` to Chaotic's Stellate edge caching endpoints (`chaotic-ahk.stellate.sh`, `chaotic-ahp.stellate.sh`)
- Improves query performance and reliability via Stellate's CDN layer

## Test plan

- [x] Verify GraphQL queries on AHK chain work correctly
- [x] Verify GraphQL queries on AHP chain work correctly
- [x] Check that collection/NFT pages load data as expected

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend GraphQL API endpoints for blockchain network services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->