### PR TITLE
chore: update AHP GraphQL schema endpoint to Stellate

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
         "schemas": [
           {
             "name": "ahp",
-            "schema": "https://ahp.gql.api.kodadot.xyz/",
+            "schema": "https://chaotic-ahp.stellate.sh/",
             "tadaOutputLocation": "./app/graphql/ahp-env.d.ts"
           }
         ]


### PR DESCRIPTION
## Summary
- Migrate the AHP GraphQL schema URL from `ahp.gql.api.kodadot.xyz` to `chaotic-ahp.stellate.sh` for improved caching and reliability
- Fixes `gql-tada generate-output` failing during `pnpm i` due to the old endpoint returning 404

## Test plan
- [x] Run `pnpm i` and verify `gql-tada generate-output` completes successfully
- [x] Confirm TypeScript types are generated correctly in `.nuxt`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the GraphQL schema endpoint configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->