### PR TITLE
fix: on page load `art_view` filter is not being respected

### DIFF
--- a/app/components/common/card/TokenCard.client.vue
+++ b/app/components/common/card/TokenCard.client.vue
@@ -78,7 +78,8 @@ const isAirdropRoute = computed(() => route.name?.toString().includes('airdrop-s
 const isCollectionRoute = computed(() => route.name?.toString().includes('chain-collection-collection_id'))
 const canAddToActionCart = computed(() => (isProfileRoute.value || isAirdropRoute.value) && dataOwner.value && isCurrentAccount(dataOwner.value) && mimeType.value?.length)
 
-const hideMediaInfo = computed(() => artViewFilter.value && isCollectionRoute.value)
+const isArtViewEnabled = computed(() => route.query.art_view?.toString() === 'true' || artViewFilter.value)
+const hideMediaInfo = computed(() => isArtViewEnabled.value && isCollectionRoute.value)
 
 watchEffect(() => {
   if (token.value && dataOwner.value && canAddToActionCart.value) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for controlling art view mode via URL query parameters. Users can now enable art view through the URL in addition to the existing filter option. Media information visibility on collection routes is now determined by both the query parameter and filter settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->