### PR TITLE
feat(explore): add skeleton loader to prices while loading 

### DIFF
--- a/app/components/common/card/TokenCard.client.vue
+++ b/app/components/common/card/TokenCard.client.vue
@@ -23,6 +23,7 @@ const {
   usdPrice,
   mediaIcon,
   nativePrice,
+  isPriceLoading,
 } = useToken(props)
 
 const isNsfw = computed(() => isNsfwNft(token.value?.metadata?.attributes))
@@ -232,7 +233,10 @@ watchEffect(() => {
                 Price
               </div>
               <div class="text-right">
-                <div v-if="price" class="flex items-baseline gap-1">
+                <div v-if="isPriceLoading" class="h-5 flex items-center">
+                  <USkeleton class="h-4 w-20 rounded" />
+                </div>
+                <div v-else-if="price" class="flex items-baseline gap-1">
                   <span class="text-sm font-semibold text-gray-900 dark:text-white truncate">{{ price }}</span>
                 </div>
                 <div v-else>
@@ -247,7 +251,10 @@ watchEffect(() => {
                 USD
               </div>
               <div class="text-right">
-                <div v-if="price" class="flex items-baseline gap-1">
+                <div v-if="isPriceLoading" class="h-5 flex items-center">
+                  <USkeleton class="h-4 w-14 rounded" />
+                </div>
+                <div v-else-if="price" class="flex items-baseline gap-1">
                   <span class="text-sm font-semibold text-gray-900 dark:text-white">{{ usdPrice || '$0.00' }}</span>
                 </div>
                 <div v-else>

--- a/app/composables/useToken.ts
+++ b/app/composables/useToken.ts
@@ -30,6 +30,7 @@ export function useToken(props: {
   const collection = ref<Awaited<ReturnType<typeof fetchOdaCollection>> | null>(null)
   const highestOffer = ref<HighestNftOffer | null>(null)
   const queryPrice = ref<string | null>(null)
+  const isPriceLoading = ref(true)
   const owner = ref<string | null>(null)
   const collectionCreator = ref<string | null>(null)
   const error = ref<unknown | null>(null)
@@ -114,6 +115,9 @@ export function useToken(props: {
       console.error('Failed to fetch token data:', err)
       error.value = err
     }
+    finally {
+      isPriceLoading.value = false
+    }
   })
 
   const price = computed(() => {
@@ -151,6 +155,7 @@ export function useToken(props: {
 
     // Computed properties
     nativePrice: queryPrice,
+    isPriceLoading,
     price,
     usdPrice,
     mediaIcon,


### PR DESCRIPTION

- ref https://github.com/chaotic-art/planning/issues/33

| Before    | After |
| -------- | ------- |
| <img  height="778" alt="CleanShot 2026-02-11 at 11 12 01@2x" src="https://github.com/user-attachments/assets/ecca863e-65ce-4582-af8b-7aba39da35be" />  |  <img height="778"  alt="CleanShot 2026-02-11 at 13 24 56@2x" src="https://github.com/user-attachments/assets/ef2328ea-6147-4b18-9d2e-a40ef0f7ef0e" /> |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading indicators for token price information. Skeleton loaders now display while prices are being fetched, providing improved visual feedback during loading states. Gracefully falls back to default text when prices are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->