### PR TITLE
🔧 collection name line-clamp-3

### DIFF
--- a/app/components/common/card/CollectionCard.client.vue
+++ b/app/components/common/card/CollectionCard.client.vue
@@ -84,7 +84,7 @@ onMounted(async () => {
 
             <!-- Collection Title -->
             <div class="flex-1 min-w-0 pb-1">
-              <h3 class="font-bold text-lg text-white leading-tight line-clamp-2 drop-shadow-lg">
+              <h3 class="font-bold text-lg text-white leading-tight line-clamp-3 drop-shadow-lg">
                 {{ item.name }}
               </h3>
 


### PR DESCRIPTION
- https://github.com/chaotic-art/app/pull/776#pullrequestreview-3786020667

- closes #514 

<img width="1021" height="271" alt="Screenshot 2026-02-12 at 08-36-56 Gallery - Explore Collections and NFTs Chaotic Labs" src="https://github.com/user-attachments/assets/fec429a4-df85-4534-b187-6ea6231c063a" />
<img width="334" height="278" alt="Screenshot 2026-02-12 at 08-39-26 Gallery - Explore Collections and NFTs Chaotic Labs" src="https://github.com/user-attachments/assets/16d7e2da-8bec-4b41-a004-a96fcb8087d3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Collection card titles now display up to three lines before truncating, making longer titles more readable.
  * Visual styling and drop-shadow are preserved; no functional or data-flow changes to the component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->