### PR TITLE
feat(rarity): improve explore nfts sorting

### DIFF
--- a/app/components/common/NftsToolbar.vue
+++ b/app/components/common/NftsToolbar.vue
@@ -27,8 +27,8 @@ const sortOptions = [
   { label: 'Oldest', value: 'blockNumber_ASC' },
   { label: 'A-Z', value: 'name_ASC' },
   { label: 'Z-A', value: 'name_DESC' },
-  { label: t('explore.sortRarestFirst'), value: 'rarityRank_ASC_NULLS_LAST' },
-  { label: t('explore.sortCommonFirst'), value: 'rarityRank_DESC_NULLS_LAST' },
+  { label: t('explore.sortRarestFirst'), value: 'rarityPercentile_ASC' },
+  { label: t('explore.sortCommonFirst'), value: 'rarityPercentile_DESC' },
 ]
 
 const listedOptions = [

--- a/app/composables/useInfiniteNfts.ts
+++ b/app/composables/useInfiniteNfts.ts
@@ -35,11 +35,17 @@ export function useInfiniteNfts(options: UseInfiniteNftsOptions = {}) {
     else if (orderBy[0] === 'blockNumber_ASC') {
       variables.orderBy = ['blockNumber_ASC', 'sn_ASC']
     }
-    else if (orderBy[0] === 'rarityRank_ASC_NULLS_LAST') {
-      variables.orderBy = ['rarityRank_ASC_NULLS_LAST', 'sn_ASC']
+    else if (orderBy[0] === 'rarityRank_ASC') {
+      variables.orderBy = ['rarityRank_ASC_NULLS_LAST', 'rarityScore_DESC_NULLS_LAST', 'sn_ASC']
     }
-    else if (orderBy[0] === 'rarityRank_DESC_NULLS_LAST') {
-      variables.orderBy = ['rarityRank_DESC_NULLS_LAST', 'sn_DESC']
+    else if (orderBy[0] === 'rarityRank_DESC') {
+      variables.orderBy = ['rarityRank_DESC_NULLS_LAST', 'rarityScore_ASC_NULLS_LAST', 'sn_DESC']
+    }
+    else if (orderBy[0] === 'rarityPercentile_ASC') {
+      variables.orderBy = ['rarityPercentile_ASC_NULLS_LAST', 'rarityScore_DESC_NULLS_LAST', 'sn_ASC']
+    }
+    else if (orderBy[0] === 'rarityPercentile_DESC') {
+      variables.orderBy = ['rarityPercentile_DESC_NULLS_LAST', 'rarityScore_ASC_NULLS_LAST', 'sn_DESC']
     }
   }
 

--- a/app/composables/useSortOptions.ts
+++ b/app/composables/useSortOptions.ts
@@ -23,9 +23,9 @@ export function useSortOptions(defaultSort = 'newest') {
       case 'oldest':
         return 'blockNumber_ASC'
       case 'rarest':
-        return 'rarityRank_ASC_NULLS_LAST'
+        return 'rarityRank_ASC'
       case 'most_common':
-        return 'rarityRank_DESC_NULLS_LAST'
+        return 'rarityRank_DESC'
       case 'lowest_price':
         return 'price_ASC'
       case 'higher_price':


### PR DESCRIPTION
## Issue

Explore “Rarest” was misleading because we used collection-relative rarityRank, causing heavy concentration (e.g., mostly collection 13).
- switched Explore rarity sorting to rarityPercentile (ASC/DESC), and added tie-breakers,  which gives more meaningful cross-collection results.
- cleaned URL sort keys (no _NULLS_LAST) while still normalizing to GraphQL *_NULLS_LAST


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated rarity-based sorting logic for improved accuracy and consistency in NFT listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<img width="3452" height="2156" alt="CleanShot 2026-02-13 at 21 01 11@2x" src="https://github.com/user-attachments/assets/995bf4d5-886b-4be5-aa64-0851d460c970" />