### PR TITLE
🔧 sort filtertraitsection by count

### DIFF
--- a/app/components/explore/filter/FilterTraitSection.vue
+++ b/app/components/explore/filter/FilterTraitSection.vue
@@ -35,7 +35,7 @@ const groupedTraits = computed(() => {
         return item.value.toLowerCase().includes(traitSearchQuery.value.toLowerCase())
           || traitType.toLowerCase().includes(traitSearchQuery.value.toLowerCase())
       })
-      .sort((a, b) => a.value.localeCompare(b.value))
+      .sort((a, b) => a.count - b.count)
 
     if (traitValues.length > 0) {
       groups.set(traitType, traitValues)


### PR DESCRIPTION
small improv

**before**
<img width="524" height="368" alt="Screenshot 2026-02-18 at 08-35-11 Chaotic Labs" src="https://github.com/user-attachments/assets/2393f930-18f3-4db7-8653-4309c581fc31" />

**after**
<img width="524" height="360" alt="Screenshot 2026-02-18 at 08-36-50 Chaotic Labs" src="https://github.com/user-attachments/assets/4bed9329-7698-41d9-a3ee-d57383701486" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trait filter values now sort by frequency of use rather than alphabetically, improving filter organization and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->