### PR TITLE
feat: improve sidebar collapse button placement

### DIFF
--- a/app/components/explore/filter/ExploreFilterToggleButton.vue
+++ b/app/components/explore/filter/ExploreFilterToggleButton.vue
@@ -1,22 +1,39 @@
 <script setup lang="ts">
-const { sidebarCollapsed, openFilters, activeFiltersCount } = useExploreFilterToggleState()
+const { sidebarCollapsed, openFilters, closeFilters, activeFiltersCount } = useExploreFilterToggleState()
+
+const icon = computed(() =>
+  sidebarCollapsed.value ? 'i-heroicons-funnel' : 'i-heroicons-chevron-double-left',
+)
+
+const tooltipText = computed(() =>
+  sidebarCollapsed.value ? 'explore.showFilters' : 'explore.hideFilters',
+)
+
+function toggleFilters() {
+  if (sidebarCollapsed.value) {
+    openFilters()
+  }
+  else {
+    closeFilters()
+  }
+}
 </script>
 
 <template>
   <ClientOnly>
-    <div v-if="sidebarCollapsed" class="hidden md:block">
-      <UTooltip :text="$t('explore.showFilters')">
+    <div class="hidden md:block">
+      <UTooltip :text="$t(tooltipText)">
         <UButton
-          icon="i-heroicons-chevron-right"
+          :icon="icon"
           color="neutral"
           variant="outline"
           size="sm"
           class="relative shrink-0 w-9! h-9 rounded-md!"
-          :aria-label="$t('explore.showFilters')"
-          @click="openFilters"
+          :aria-label="$t(tooltipText)"
+          @click="toggleFilters"
         >
           <UBadge
-            v-if="activeFiltersCount > 0"
+            v-if="sidebarCollapsed && activeFiltersCount > 0"
             :label="String(activeFiltersCount)"
             size="xs"
             class="absolute -top-1 -right-1"

--- a/app/components/explore/filter/ExploreFilters.vue
+++ b/app/components/explore/filter/ExploreFilters.vue
@@ -240,18 +240,7 @@ watch(priceBy, (newPriceBy, oldPriceBy) => {
           sticky
         >
           <div class="p-3 border-b border-border">
-            <FilterHeader>
-              <template #actions>
-                <UTooltip :text="$t('explore.hideFilters')">
-                  <UButton
-                    variant="ghost"
-                    icon="i-heroicons-chevron-left"
-                    size="sm"
-                    @click="sidebarCollapsed = true"
-                  />
-                </UTooltip>
-              </template>
-            </FilterHeader>
+            <FilterHeader />
           </div>
 
           <div class="p-3 overflow-y-auto max-h-[calc(100vh-300px)]">

--- a/app/composables/useExploreFilterToggleState.ts
+++ b/app/composables/useExploreFilterToggleState.ts
@@ -31,9 +31,14 @@ export function useExploreFilterToggleState() {
     sidebarCollapsed.value = false
   }
 
+  function closeFilters() {
+    sidebarCollapsed.value = true
+  }
+
   return {
     sidebarCollapsed,
     activeFiltersCount,
     openFilters,
+    closeFilters,
   }
 }


### PR DESCRIPTION
## What happened

Unified the desktop filter toggle into a single fixed location to eliminate the visual “jump” between expanded and collapsed states.
The same control now swaps icon/action (hide vs show, keeping interaction consistent. 

- ref https://github.com/chaotic-art/planning/issues/33

<img width="1728" height="1117" alt="desktop-active-collapsed" src="https://github.com/user-attachments/assets/f60f2d01-49ee-4f64-bbf4-7f413b47c5a1" />

<img width="1728" height="1117" alt="desktop-active-expanded" src="https://github.com/user-attachments/assets/058da4d9-7160-4f74-832d-316c67fff0e0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Filter toggle button now displays dynamic tooltip text and icon based on current state.
  * Filter badge visibility improved to display only when appropriate.

* **Bug Fixes**
  * Removed redundant collapse control from filter header to streamline UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->