### PR TITLE
🔧 landing chainIcon darkmode clientOnly

### DIFF
--- a/app/components/landing/drop/LandingHorizontalDropCard.vue
+++ b/app/components/landing/drop/LandingHorizontalDropCard.vue
@@ -91,7 +91,7 @@ useHead({
 
               <span class="font-bold text-muted-foreground">·</span>
               <div v-if="drop?.chain" class="flex items-center gap-1">
-                <img v-if="chainIcon" :src="chainIcon" class="w-4 h-4" :alt="drop.chain">
+                <ClientOnly><img v-if="chainIcon" :src="chainIcon" class="w-4 h-4" :alt="drop.chain"></ClientOnly>
                 <span class="font-medium text-foreground">{{ chainSpec[drop.chain].tokenSymbol }}</span>
               </div>
             </template>

--- a/app/components/landing/drop/LandingSubDropCard.vue
+++ b/app/components/landing/drop/LandingSubDropCard.vue
@@ -60,7 +60,7 @@ const { usd: usdPrice } = useAmount(computed(() => props.drop?.price), decimals,
             <template v-if="drop?.chain">
               <span class="font-bold text-muted-foreground">·</span>
               <div class="flex items-center gap-1">
-                <img v-if="chainIcon" :src="chainIcon" class="w-4 h-4 flex-shrink-0" :alt="drop.chain">
+                <ClientOnly><img v-if="chainIcon" :src="chainIcon" class="w-4 h-4 shrink-0" :alt="drop.chain"></ClientOnly>
                 <div class="capitalize text-foreground">
                   {{ chainSpec[drop.chain].tokenSymbol }}
                 </div>


### PR DESCRIPTION
Small fix, on first load app show icon on clientOnly (theme color not applied on server side)

**before**
<img width="720" height="362" alt="Screenshot 2026-02-19 at 11-05-40 Chaotic Labs" src="https://github.com/user-attachments/assets/f03c45b0-0736-4854-abdd-d6271793d4df" />

**after**
<img width="708" height="426" alt="Screenshot 2026-02-19 at 11-05-48 Chaotic Labs" src="https://github.com/user-attachments/assets/0a8c113c-2471-42b9-bb2b-4ad05be0a364" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chain icon rendering to ensure proper display in client-side environments.
  * Refined icon spacing styling for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->