### PR TITLE
fix: unneeded fetch in NftsGrid

### DIFF
--- a/app/components/explore/NftsGrid.vue
+++ b/app/components/explore/NftsGrid.vue
@@ -64,21 +64,31 @@ function getRarity(nft: { rarity?: NftRarity | null }): NftRarity | null {
   <div class="space-y-8">
     <!-- Grid Content -->
     <div :class="props.gridClass">
-      <TokenCard
-        v-for="nft in nfts"
-        :key="`${prefix}-${nft.collectionId}-${nft.tokenId}-${nft.image}`"
-        :token-id="nft.tokenId"
-        :collection-id="nft.collectionId"
-        :chain="nft.chain"
-        :class="{ 'animate-pulse': nft.isPlaceholder }"
-        :image="nft.image"
-        :name="nft.name"
-        :price="nft.price"
-        :current-owner="nft.currentOwner"
-        :hide-hover-action="hideHoverAction"
-        :show-rarity="showRarity"
-        :rarity="getRarity(nft)"
-      />
+      <template v-for="nft in nfts" :key="nft.isPlaceholder ? nft.id : `${prefix}-${nft.collectionId}-${nft.tokenId}-${nft.image}`">
+        <div
+          v-if="nft.isPlaceholder"
+          class="relative border border-gray-300 dark:border-neutral-700 rounded-xl overflow-hidden"
+        >
+          <USkeleton class="aspect-square w-full rounded-none" />
+          <div class="p-3 md:p-4 space-y-2">
+            <USkeleton class="h-4 w-3/4 rounded" />
+            <USkeleton class="h-3 w-1/2 rounded" />
+          </div>
+        </div>
+        <TokenCard
+          v-else
+          :token-id="nft.tokenId"
+          :collection-id="nft.collectionId"
+          :chain="nft.chain"
+          :image="nft.image"
+          :name="nft.name"
+          :price="nft.price"
+          :current-owner="nft.currentOwner"
+          :hide-hover-action="hideHoverAction"
+          :show-rarity="showRarity"
+          :rarity="getRarity(nft)"
+        />
+      </template>
 
       <slot name="additional-item" />
     </div>

--- a/app/composables/useInfiniteNfts.ts
+++ b/app/composables/useInfiniteNfts.ts
@@ -70,14 +70,14 @@ export function useInfiniteNfts(options: UseInfiniteNftsOptions = {}) {
 
   // Transform display items for the template with proper typing
   const nfts = computed(() => {
-    return infiniteQuery.displayItems.value.map((item) => {
+    return infiniteQuery.displayItems.value.map((item, index) => {
       // Type guard for placeholder items
       if (item.isPlaceholder) {
         return {
           id: item.id,
           name: item.name,
-          tokenId: Math.floor(Math.random() * 1000) + 1,
-          collectionId: Math.floor(Math.random() * 100) + 1,
+          tokenId: index,
+          collectionId: index,
           chain: endpoint,
           image: item.image,
           isPlaceholder: true,


### PR DESCRIPTION
Render skeleton cards for placeholder items instead of TokenCard, avoiding unnecessary token/collection fetches during infinite scroll. Use index-based ids for placeholders in useInfiniteNfts.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading state display in NFT grids with dedicated skeleton placeholders, providing better visual feedback while content loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->