### PR TITLE
feat: enable site indexing for SEO

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -15,7 +15,7 @@ export default defineNuxtConfig({
 
   site: {
     name: 'Chaotic Labs',
-    indexable: false,
+    indexable: true,
   },
 
   seo: {


### PR DESCRIPTION
Enables `site.indexable` in Nuxt config so the site can be indexed by search engines.

**Change:** `nuxt.config.ts` — `site.indexable` set from `false` to `true`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled site indexability to improve discoverability by search engines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->