### PR TITLE
feat(advanced-filtering): Smart sorting options 

### DIFF
--- a/app/components/common/NftsToolbar.vue
+++ b/app/components/common/NftsToolbar.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
+import type { LocationQueryRaw } from 'vue-router'
+import type { SortQueryValue } from '~/utils/sort'
+import { getSingleQueryValue } from '~/utils/query'
+
 interface QueryState {
-  sort: { label: string, value: string }
+  sortKeys: string[]
   search: string
   listed: { label: string, value: string, disabled?: boolean }
   owned: boolean
@@ -21,12 +25,16 @@ const route = useRoute()
 const router = useRouter()
 const { accountId } = useAuth()
 const { t } = useI18n()
-const { sortOptions, defaultSortKey, normalizeSortKey, getSortDefinition } = useSortOptions('exploreNfts')
+const {
+  sortOptions,
+  normalizeSortKeys,
+  buildOrderBy,
+  requiresListed,
+  applySortQuery,
+} = useSortOptions('exploreNfts')
 
 const listedOptions = computed(() => {
-  const sortKey = normalizeSortKey(route.query.sort)
-  const selectedSortDefinition = getSortDefinition(sortKey)
-  const unlistedDisabled = Boolean(selectedSortDefinition.requiresListed)
+  const unlistedDisabled = requiresListed(route.query.sort)
 
   return [
     { label: 'All', value: '' },
@@ -37,44 +45,44 @@ const listedOptions = computed(() => {
 
 const queryState = computed({
   get: () => {
-    const sort = sortOptions.value.find(opt => opt.value === normalizeSortKey(route.query.sort)) || sortOptions.value[0] as QueryState['sort']
-    const selectedSortDefinition = getSortDefinition(sort.value)
-    const listedFromQuery = listedOptions.value.find(opt => opt.value === route.query.listed) || listedOptions.value[0] as QueryState['listed']
-    const listed = selectedSortDefinition.requiresListed
+    const sortKeys = normalizeSortKeys(route.query.sort)
+    const listedFromQuery = listedOptions.value.find(opt => opt.value === getSingleQueryValue(route.query.listed)) || listedOptions.value[0] as QueryState['listed']
+    const listed = requiresListed(sortKeys)
       ? listedOptions.value.find(opt => opt.value === 'true') || listedOptions.value[0] as QueryState['listed']
       : listedFromQuery
 
     return {
-      sort,
-      search: route.query.search as string || '',
+      sortKeys,
+      search: getSingleQueryValue(route.query.search),
       listed,
-      owned: route.query.owned === 'true',
+      owned: getSingleQueryValue(route.query.owned) === 'true',
     }
   },
-  set: ({ sort, search, listed, owned }: { sort?: QueryState['sort'], search?: string, listed?: QueryState['listed'], owned?: boolean }) => {
-    const query = { ...route.query }
-    const sortKey = sort?.value ? normalizeSortKey(sort.value) : normalizeSortKey(route.query.sort)
-    const selectedSortDefinition = getSortDefinition(sortKey)
-    const listedValue = selectedSortDefinition.requiresListed ? 'true' : listed?.value
+  set: ({ sortKeys, search, listed, owned }: { sortKeys?: string[], search?: string, listed?: QueryState['listed'], owned?: boolean }) => {
+    const query: LocationQueryRaw = { ...route.query }
+    const nextSortKeys = applySortQuery(query, sortKeys ?? route.query.sort)
+    const listedValue = requiresListed(nextSortKeys) ? 'true' : listed?.value
 
-    if (sortKey === defaultSortKey)
-      delete query.sort
-    else
-      query.sort = sortKey
-
-    if (!search)
+    if (!search) {
       delete query.search
-    else query.search = search
+    }
+    else {
+      query.search = search
+    }
 
-    if (listedValue)
+    if (listedValue) {
       query.listed = listedValue
-    else
+    }
+    else {
       delete query.listed
+    }
 
-    if (owned)
+    if (owned) {
       query.owned = owned.toString()
-    else
+    }
+    else {
       delete query.owned
+    }
 
     router.push({ query })
   },
@@ -85,9 +93,9 @@ function updateQueryState(updates: Partial<QueryState>) {
   const nextState: QueryState = { ...currentState, ...updates }
 
   // If listed was only auto-forced by a price sort, reset back to All when leaving price sorts.
-  if (updates.sort && !updates.listed) {
-    const currentSortRequiresListed = getSortDefinition(currentState.sort.value).requiresListed
-    const nextSortRequiresListed = getSortDefinition(nextState.sort.value).requiresListed
+  if (updates.sortKeys && !updates.listed) {
+    const currentSortRequiresListed = requiresListed(currentState.sortKeys)
+    const nextSortRequiresListed = requiresListed(nextState.sortKeys)
 
     if (currentSortRequiresListed && !nextSortRequiresListed) {
       nextState.listed = listedOptions.value.find(opt => opt.value === '') || listedOptions.value[0] as QueryState['listed']
@@ -95,39 +103,41 @@ function updateQueryState(updates: Partial<QueryState>) {
   }
 
   queryState.value = nextState
-
-  const queryVariables = computeQueryVariables(queryState.value)
-  emit('update:queryVariables', queryVariables)
 }
 
-function computeQueryVariables(queryState: QueryState) {
-  const sortKey = queryState.sort?.value || defaultSortKey
-  const selectedSort = getSortDefinition(sortKey)
-  const search = queryState.search
+function computeQueryVariables(state: QueryState) {
+  const selectedSortKeys = state.sortKeys
+  const orderBy = buildOrderBy(selectedSortKeys)
+  const search = state.search
   const listedVariables: Record<string, unknown> = {}
-  const listedValue = queryState.listed?.value
+  const listedValue = state.listed?.value
+  const sortRequiresListed = requiresListed(selectedSortKeys)
 
-  if (selectedSort.requiresListed || listedValue === 'true') {
+  if (sortRequiresListed || listedValue === 'true') {
     listedVariables.search = { price_gt: '0' }
   }
   else if (listedValue === 'false') {
     listedVariables.price_isNull = true
   }
 
-  const ownedVariables = props.hasOwnedFilter && queryState.owned && accountId.value
+  const ownedVariables = props.hasOwnedFilter && state.owned && accountId.value
     ? { owner: accountId.value }
     : {}
 
   return {
     ...props.extraVariables,
-    orderBy: selectedSort.orderBy,
+    orderBy,
     ...(search && { name: search }),
     ...listedVariables,
     ...ownedVariables,
   }
 }
 
-// Watch for changes in queryState and emit updated queryVariables
+function handleSortKeysUpdate(value: SortQueryValue) {
+  const nextSortKeys = normalizeSortKeys(value)
+  updateQueryState({ sortKeys: nextSortKeys })
+}
+
 watch(() => queryState.value, (newValue) => {
   const queryVariables = computeQueryVariables(newValue)
   emit('update:queryVariables', queryVariables)
@@ -136,7 +146,6 @@ watch(() => queryState.value, (newValue) => {
 
 <template>
   <div class="flex items-center gap-2 flex-wrap">
-    <!-- Chain Switcher -->
     <ChainSwitcher />
 
     <UInput
@@ -148,13 +157,15 @@ watch(() => queryState.value, (newValue) => {
     />
 
     <USelectMenu
-      :model-value="queryState.sort"
+      :model-value="queryState.sortKeys"
       :items="sortOptions"
       :placeholder="t('explore.sortBy')"
       class="w-40"
       :search-input="false"
+      value-key="value"
+      multiple
       :ui="{ content: 'min-w-50 max-h-80 overflow-y-auto' }"
-      @update:model-value="updateQueryState({ sort: $event })"
+      @update:model-value="handleSortKeysUpdate"
     />
 
     <USelectMenu

--- a/app/components/common/SortOptions.vue
+++ b/app/components/common/SortOptions.vue
@@ -6,7 +6,7 @@ interface SortOption {
 }
 
 interface Props {
-  modelValue: string
+  modelValue: string[]
   options?: SortOption[]
   placeholder?: string
 }
@@ -17,20 +17,21 @@ const props = withDefaults(defineProps<Props>(), {
 })
 
 const emit = defineEmits<{
-  'update:modelValue': [value: string]
+  'update:modelValue': [value: string[]]
 }>()
 
-const selectedSort = computed({
+const selectedSorts = computed({
   get: () => props.modelValue,
-  set: (value: string) => emit('update:modelValue', value),
+  set: (value: string[]) => emit('update:modelValue', value),
 })
 </script>
 
 <template>
   <USelectMenu
-    v-model="selectedSort"
+    v-model="selectedSorts"
     :items="options"
     value-key="value"
+    multiple
     :placeholder="placeholder"
     class="w-40"
     :search-input="false"

--- a/app/pages/[chain]/collection/[collection_id].vue
+++ b/app/pages/[chain]/collection/[collection_id].vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { LocationQueryRaw } from 'vue-router'
 import type { SelectedTrait } from '@/components/trait/types'
 import type { AssetHubChain } from '~/plugins/sdk.client'
 import { CHAINS } from '@kodadot1/static'
@@ -10,7 +11,13 @@ const route = useRoute()
 const router = useRouter()
 const { chain: chainPrefix, collection_id } = route.params
 const { isCurrentAccount, isLogIn } = useAuth()
-const { sortOptions, defaultSortKey, normalizeSortKey, getSortDefinition } = useSortOptions('collectionItems')
+const {
+  sortOptions,
+  normalizeSortKeys,
+  buildOrderBy,
+  requiresListed,
+  applySortQuery,
+} = useSortOptions('collectionItems')
 
 const tabsItems = ref([
   {
@@ -78,16 +85,11 @@ const collectionRarityTotalItems = computed(() => {
     : null
 })
 
-const selectedSort = computed({
-  get: () => normalizeSortKey(route.query.sort),
-  set: (value: string) => {
-    const query = { ...route.query }
-    const sortKey = normalizeSortKey(value)
-
-    if (sortKey === defaultSortKey)
-      delete query.sort
-    else
-      query.sort = sortKey
+const selectedSortKeys = computed({
+  get: () => normalizeSortKeys(route.query.sort),
+  set: (value: string[]) => {
+    const query: LocationQueryRaw = { ...route.query }
+    applySortQuery(query, value)
 
     router.replace({ query })
   },
@@ -100,17 +102,16 @@ const gridKey = computed(() => {
   const serializedQuery = serializeQueryForKey(route.query, NFT_GRID_NON_FETCH_QUERY_KEYS)
 
   return [
-    selectedSort.value,
+    selectedSortKeys.value.join(','),
     filteredNftIds.value.join(','),
     serializedQuery,
   ].join('::')
 })
 
 const queryVariables = computed(() => {
-  const selectedSortDefinition = getSortDefinition(selectedSort.value)
   const baseVariables: Record<string, unknown> = {
     collections: [collection_id?.toString() ?? ''],
-    orderBy: selectedSortDefinition.orderBy,
+    orderBy: buildOrderBy(selectedSortKeys.value),
   }
 
   const searchFilters: Record<string, unknown>[] = []
@@ -122,7 +123,7 @@ const queryVariables = computed(() => {
   const nftFilters = buildNftSearchFilters({ query: route.query })
   searchFilters.push(...nftFilters)
 
-  if (selectedSortDefinition.requiresListed) {
+  if (requiresListed(selectedSortKeys.value)) {
     const hasPriceConstraint = searchFilters.some(
       filter => Object.hasOwn(filter, 'price_gt') || Object.hasOwn(filter, 'price_gte'),
     )
@@ -304,7 +305,7 @@ defineOgImageComponent('Frame', {
                 <div class="w-full md:w-auto flex items-center gap-2 md:ml-auto">
                   <ArtViewFilter />
                   <SortOptions
-                    v-model="selectedSort"
+                    v-model="selectedSortKeys"
                     :options="sortOptions"
                     class="w-40"
                   />

--- a/app/utils/query.ts
+++ b/app/utils/query.ts
@@ -15,6 +15,14 @@ export function parseQueryNumber(
   return Number.isFinite(parsed) ? parsed : null
 }
 
+export function getSingleQueryValue(value: QueryValue): string {
+  if (Array.isArray(value)) {
+    return typeof value[0] === 'string' ? value[0] : ''
+  }
+
+  return typeof value === 'string' ? value : ''
+}
+
 function serializeQueryValue(
   value: LocationQueryValue | LocationQueryValue[] | null | undefined,
 ): string {

--- a/app/utils/sort.spec.ts
+++ b/app/utils/sort.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildOrderBy,
+  dropImplicitDefaultSort,
+  normalizeSortKeys,
+  requiresListed,
+  sortKeysToQueryValue,
+  toggleSortKey,
+} from './sort'
+
+describe('sort utilities', () => {
+  it('falls back to default key when sort query is empty or invalid', () => {
+    expect(normalizeSortKeys('exploreNfts', undefined)).toEqual(['recent'])
+    expect(normalizeSortKeys('exploreNfts', '')).toEqual(['recent'])
+    expect(normalizeSortKeys('exploreNfts', ['invalid'])).toEqual(['recent'])
+  })
+
+  it('parses single, repeated, and comma-separated sort query values', () => {
+    expect(normalizeSortKeys('exploreNfts', 'price_low')).toEqual(['price_low'])
+    expect(normalizeSortKeys('exploreNfts', ['recent', 'price_low'])).toEqual(['recent', 'price_low'])
+    expect(normalizeSortKeys('exploreNfts', 'recent,price_low')).toEqual(['recent', 'price_low'])
+  })
+
+  it('drops implicit default sort only when query had no explicit sort', () => {
+    expect(dropImplicitDefaultSort(['recent', 'price_low'], 'recent', false)).toEqual(['price_low'])
+    expect(dropImplicitDefaultSort(['recent', 'price_low'], 'recent', true)).toEqual(['recent', 'price_low'])
+    expect(dropImplicitDefaultSort(['recent'], 'recent', false)).toEqual(['recent'])
+  })
+
+  it('toggles opposite group sorts by replacing the previous value', () => {
+    expect(toggleSortKey('exploreNfts', ['recent'], 'oldest')).toEqual(['oldest'])
+    expect(toggleSortKey('exploreNfts', ['recent', 'price_low'], 'price_low')).toEqual(['recent'])
+  })
+
+  it('builds orderBy by selected priority then tie-breakers', () => {
+    expect(buildOrderBy('exploreNfts', ['recent'])).toEqual(['blockNumber_DESC', 'sn_DESC'])
+    expect(buildOrderBy('exploreNfts', ['recent', 'price_low'])).toEqual(['blockNumber_DESC', 'price_ASC', 'sn_DESC'])
+  })
+
+  it('deduplicates conflicting tie-breaker fields by keeping the first occurrence', () => {
+    expect(buildOrderBy('exploreNfts', ['recent', 'rarest'])).toEqual([
+      'blockNumber_DESC',
+      'rarityPercentile_ASC_NULLS_LAST',
+      'sn_DESC',
+      'rarityScore_DESC_NULLS_LAST',
+    ])
+  })
+
+  it('returns true for requiresListed when any selected sort requires listings', () => {
+    expect(requiresListed('exploreNfts', ['recent'])).toBe(false)
+    expect(requiresListed('exploreNfts', ['recent', 'price_low'])).toBe(true)
+  })
+
+  it('serializes sort keys to route query values', () => {
+    expect(sortKeysToQueryValue(['recent'], 'recent')).toBeUndefined()
+    expect(sortKeysToQueryValue(['price_low'], 'recent')).toBe('price_low')
+    expect(sortKeysToQueryValue(['recent', 'price_low'], 'recent')).toEqual(['recent', 'price_low'])
+  })
+})

--- a/app/utils/sort.ts
+++ b/app/utils/sort.ts
@@ -1,32 +1,227 @@
+export type SortGroup = 'time' | 'price' | 'rarity' | 'name'
+export type SortQueryValue = string | null | undefined | Array<string | null | undefined>
+
+export interface SortDefinition {
+  key: string
+  labelKey: string
+  group: SortGroup
+  primaryOrderBy: readonly string[]
+  tieBreakerOrderBy?: readonly string[]
+  requiresListed?: boolean
+  icon?: string
+}
+
 export const SORT_OPTIONS = {
   exploreNfts: [
-    { key: 'recent', labelKey: 'explore.sortRecentlyListed', orderBy: ['blockNumber_DESC', 'sn_DESC'], icon: 'i-heroicons-clock' },
-    { key: 'oldest', labelKey: 'explore.sortOldest', orderBy: ['blockNumber_ASC', 'sn_ASC'], icon: 'i-heroicons-archive-box' },
-    { key: 'price_low', labelKey: 'explore.sortPriceLowToHigh', orderBy: ['price_ASC'], requiresListed: true, icon: 'i-heroicons-arrow-trending-down' },
-    { key: 'price_high', labelKey: 'explore.sortPriceHighToLow', orderBy: ['price_DESC'], requiresListed: true, icon: 'i-heroicons-arrow-trending-up' },
-    { key: 'rarest', labelKey: 'explore.sortRarestFirst', orderBy: ['rarityPercentile_ASC_NULLS_LAST', 'rarityScore_DESC_NULLS_LAST', 'sn_ASC'], icon: 'i-heroicons-sparkles' },
-    { key: 'common', labelKey: 'explore.sortCommonFirst', orderBy: ['rarityPercentile_DESC_NULLS_LAST', 'rarityScore_ASC_NULLS_LAST', 'sn_DESC'], icon: 'i-heroicons-squares-2x2' },
-    { key: 'name_asc', labelKey: 'explore.sortNameAsc', orderBy: ['name_ASC'], icon: 'i-heroicons-arrow-up' },
-    { key: 'name_desc', labelKey: 'explore.sortNameDesc', orderBy: ['name_DESC'], icon: 'i-heroicons-arrow-down' },
+    { key: 'recent', labelKey: 'explore.sortRecentlyListed', group: 'time', primaryOrderBy: ['blockNumber_DESC'], tieBreakerOrderBy: ['sn_DESC'], icon: 'i-heroicons-clock' },
+    { key: 'oldest', labelKey: 'explore.sortOldest', group: 'time', primaryOrderBy: ['blockNumber_ASC'], tieBreakerOrderBy: ['sn_ASC'], icon: 'i-heroicons-archive-box' },
+    { key: 'price_low', labelKey: 'explore.sortPriceLowToHigh', group: 'price', primaryOrderBy: ['price_ASC'], requiresListed: true, icon: 'i-heroicons-arrow-trending-down' },
+    { key: 'price_high', labelKey: 'explore.sortPriceHighToLow', group: 'price', primaryOrderBy: ['price_DESC'], requiresListed: true, icon: 'i-heroicons-arrow-trending-up' },
+    { key: 'rarest', labelKey: 'explore.sortRarestFirst', group: 'rarity', primaryOrderBy: ['rarityPercentile_ASC_NULLS_LAST'], tieBreakerOrderBy: ['rarityScore_DESC_NULLS_LAST', 'sn_ASC'], icon: 'i-heroicons-sparkles' },
+    { key: 'common', labelKey: 'explore.sortCommonFirst', group: 'rarity', primaryOrderBy: ['rarityPercentile_DESC_NULLS_LAST'], tieBreakerOrderBy: ['rarityScore_ASC_NULLS_LAST', 'sn_DESC'], icon: 'i-heroicons-squares-2x2' },
+    { key: 'name_asc', labelKey: 'explore.sortNameAsc', group: 'name', primaryOrderBy: ['name_ASC'], icon: 'i-heroicons-arrow-up' },
+    { key: 'name_desc', labelKey: 'explore.sortNameDesc', group: 'name', primaryOrderBy: ['name_DESC'], icon: 'i-heroicons-arrow-down' },
   ],
   collectionItems: [
-    { key: 'recent', labelKey: 'explore.sortRecentlyListed', orderBy: ['blockNumber_DESC', 'sn_DESC'], icon: 'i-heroicons-clock' },
-    { key: 'oldest', labelKey: 'explore.sortOldest', orderBy: ['blockNumber_ASC', 'sn_ASC'], icon: 'i-heroicons-archive-box' },
-    { key: 'price_low', labelKey: 'explore.sortPriceLowToHigh', orderBy: ['price_ASC'], requiresListed: true, icon: 'i-heroicons-arrow-trending-down' },
-    { key: 'price_high', labelKey: 'explore.sortPriceHighToLow', orderBy: ['price_DESC'], requiresListed: true, icon: 'i-heroicons-arrow-trending-up' },
-    { key: 'rarest', labelKey: 'explore.sortRarestFirst', orderBy: ['rarityRank_ASC_NULLS_LAST', 'rarityScore_DESC_NULLS_LAST', 'sn_ASC'], icon: 'i-heroicons-sparkles' },
-    { key: 'common', labelKey: 'explore.sortCommonFirst', orderBy: ['rarityRank_DESC_NULLS_LAST', 'rarityScore_ASC_NULLS_LAST', 'sn_DESC'], icon: 'i-heroicons-squares-2x2' },
+    { key: 'recent', labelKey: 'explore.sortRecentlyListed', group: 'time', primaryOrderBy: ['blockNumber_DESC'], tieBreakerOrderBy: ['sn_DESC'], icon: 'i-heroicons-clock' },
+    { key: 'oldest', labelKey: 'explore.sortOldest', group: 'time', primaryOrderBy: ['blockNumber_ASC'], tieBreakerOrderBy: ['sn_ASC'], icon: 'i-heroicons-archive-box' },
+    { key: 'price_low', labelKey: 'explore.sortPriceLowToHigh', group: 'price', primaryOrderBy: ['price_ASC'], requiresListed: true, icon: 'i-heroicons-arrow-trending-down' },
+    { key: 'price_high', labelKey: 'explore.sortPriceHighToLow', group: 'price', primaryOrderBy: ['price_DESC'], requiresListed: true, icon: 'i-heroicons-arrow-trending-up' },
+    { key: 'rarest', labelKey: 'explore.sortRarestFirst', group: 'rarity', primaryOrderBy: ['rarityRank_ASC_NULLS_LAST'], tieBreakerOrderBy: ['rarityScore_DESC_NULLS_LAST', 'sn_ASC'], icon: 'i-heroicons-sparkles' },
+    { key: 'common', labelKey: 'explore.sortCommonFirst', group: 'rarity', primaryOrderBy: ['rarityRank_DESC_NULLS_LAST'], tieBreakerOrderBy: ['rarityScore_ASC_NULLS_LAST', 'sn_DESC'], icon: 'i-heroicons-squares-2x2' },
   ],
   exploreCollections: [
-    { key: 'recent', labelKey: 'explore.sortRecentlyListed', orderBy: ['blockNumber_DESC'], icon: 'i-heroicons-clock' },
-    { key: 'oldest', labelKey: 'explore.sortOldest', orderBy: ['blockNumber_ASC'], icon: 'i-heroicons-archive-box' },
-    { key: 'name_asc', labelKey: 'explore.sortNameAsc', orderBy: ['name_ASC'], icon: 'i-heroicons-arrow-up' },
-    { key: 'name_desc', labelKey: 'explore.sortNameDesc', orderBy: ['name_DESC'], icon: 'i-heroicons-arrow-down' },
+    { key: 'recent', labelKey: 'explore.sortRecentlyListed', group: 'time', primaryOrderBy: ['blockNumber_DESC'], icon: 'i-heroicons-clock' },
+    { key: 'oldest', labelKey: 'explore.sortOldest', group: 'time', primaryOrderBy: ['blockNumber_ASC'], icon: 'i-heroicons-archive-box' },
+    { key: 'name_asc', labelKey: 'explore.sortNameAsc', group: 'name', primaryOrderBy: ['name_ASC'], icon: 'i-heroicons-arrow-up' },
+    { key: 'name_desc', labelKey: 'explore.sortNameDesc', group: 'name', primaryOrderBy: ['name_DESC'], icon: 'i-heroicons-arrow-down' },
   ],
-} as const
+} as const satisfies Record<string, readonly SortDefinition[]>
 
 export type SortContext = keyof typeof SORT_OPTIONS
-export type SortDefinition = ((typeof SORT_OPTIONS)[SortContext][number]) & {
-  orderBy: readonly string[]
-  requiresListed?: boolean
+
+const ORDER_BY_PATTERN = /^(.*)_(?:ASC|DESC)(?:_NULLS_(?:FIRST|LAST))?$/
+
+function getSortDefinitions(context: SortContext): readonly SortDefinition[] {
+  return SORT_OPTIONS[context]
+}
+
+function getSortDefinitionMap(context: SortContext): Map<string, SortDefinition> {
+  return new Map(getSortDefinitions(context).map(definition => [definition.key, definition]))
+}
+
+function getDefaultSortKey(context: SortContext): string {
+  return getSortDefinitions(context)[0]?.key || ''
+}
+
+function splitSortEntry(entry: string): string[] {
+  return entry
+    .split(',')
+    .map(item => item.trim())
+    .filter(Boolean)
+}
+
+function extractSortKeys(value: SortQueryValue): string[] {
+  if (Array.isArray(value)) {
+    return value
+      .flatMap(item => (typeof item === 'string' ? splitSortEntry(item) : []))
+  }
+
+  if (typeof value === 'string') {
+    return splitSortEntry(value)
+  }
+
+  return []
+}
+
+function getOrderByField(orderBy: string): string {
+  const match = ORDER_BY_PATTERN.exec(orderBy)
+  return match?.[1] || orderBy
+}
+
+function dedupeOrderBy(orderByValues: string[]): string[] {
+  const seenFields = new Set<string>()
+  const dedupedValues: string[] = []
+
+  for (const orderByValue of orderByValues) {
+    const field = getOrderByField(orderByValue)
+
+    if (seenFields.has(field)) {
+      continue
+    }
+
+    seenFields.add(field)
+    dedupedValues.push(orderByValue)
+  }
+
+  return dedupedValues
+}
+
+export function normalizeSortKeys(context: SortContext, rawSortKeys: SortQueryValue): string[] {
+  const defaultSortKey = getDefaultSortKey(context)
+  const definitionByKey = getSortDefinitionMap(context)
+  const extractedSortKeys = extractSortKeys(rawSortKeys)
+
+  let normalizedSortKeys: string[] = []
+
+  for (const sortKey of extractedSortKeys) {
+    const definition = definitionByKey.get(sortKey)
+
+    if (!definition) {
+      continue
+    }
+
+    if (normalizedSortKeys.includes(sortKey)) {
+      continue
+    }
+
+    normalizedSortKeys = normalizedSortKeys.filter((existingSortKey) => {
+      const existingDefinition = definitionByKey.get(existingSortKey)
+      return existingDefinition?.group !== definition.group
+    })
+
+    normalizedSortKeys.push(sortKey)
+  }
+
+  if (normalizedSortKeys.length === 0) {
+    return defaultSortKey ? [defaultSortKey] : []
+  }
+
+  return normalizedSortKeys
+}
+
+export function toggleSortKey(context: SortContext, currentSortKeys: SortQueryValue, toggledSortKey: string): string[] {
+  const definitionByKey = getSortDefinitionMap(context)
+  const toggledDefinition = definitionByKey.get(toggledSortKey)
+
+  if (!toggledDefinition) {
+    return normalizeSortKeys(context, currentSortKeys)
+  }
+
+  const normalizedCurrentSortKeys = normalizeSortKeys(context, currentSortKeys)
+
+  if (normalizedCurrentSortKeys.includes(toggledSortKey)) {
+    const nextSortKeys = normalizedCurrentSortKeys.filter(sortKey => sortKey !== toggledSortKey)
+    return nextSortKeys.length > 0 ? nextSortKeys : normalizeSortKeys(context, [])
+  }
+
+  const nextSortKeys = normalizedCurrentSortKeys
+    .filter((sortKey) => {
+      const definition = definitionByKey.get(sortKey)
+      return definition?.group !== toggledDefinition.group
+    })
+
+  nextSortKeys.push(toggledSortKey)
+
+  return nextSortKeys.length > 0 ? nextSortKeys : normalizeSortKeys(context, [])
+}
+
+export function buildOrderBy(context: SortContext, selectedSortKeys: SortQueryValue): string[] {
+  const definitionByKey = getSortDefinitionMap(context)
+  const normalizedSortKeys = normalizeSortKeys(context, selectedSortKeys)
+  const primaryOrderByValues: string[] = []
+  const tieBreakerOrderByValues: string[] = []
+
+  for (const sortKey of normalizedSortKeys) {
+    const definition = definitionByKey.get(sortKey)
+
+    if (!definition) {
+      continue
+    }
+
+    primaryOrderByValues.push(...definition.primaryOrderBy)
+
+    if (definition.tieBreakerOrderBy?.length) {
+      tieBreakerOrderByValues.push(...definition.tieBreakerOrderBy)
+    }
+  }
+
+  return dedupeOrderBy([...primaryOrderByValues, ...tieBreakerOrderByValues])
+}
+
+export function requiresListed(context: SortContext, selectedSortKeys: SortQueryValue): boolean {
+  const definitionByKey = getSortDefinitionMap(context)
+  const normalizedSortKeys = normalizeSortKeys(context, selectedSortKeys)
+
+  return normalizedSortKeys.some(sortKey => Boolean(definitionByKey.get(sortKey)?.requiresListed))
+}
+
+export function sortKeysToQueryValue(selectedSortKeys: string[], defaultSortKey: string): string[] | string | undefined {
+  const normalizedUniqueSortKeys = selectedSortKeys
+    .filter(sortKey => typeof sortKey === 'string' && sortKey.length > 0)
+    .filter((sortKey, index, keys) => keys.indexOf(sortKey) === index)
+
+  if (normalizedUniqueSortKeys.length === 0) {
+    return undefined
+  }
+
+  if (normalizedUniqueSortKeys.length === 1 && normalizedUniqueSortKeys[0] === defaultSortKey) {
+    return undefined
+  }
+
+  if (normalizedUniqueSortKeys.length === 1) {
+    return normalizedUniqueSortKeys[0]
+  }
+
+  return normalizedUniqueSortKeys
+}
+
+export function dropImplicitDefaultSort(
+  selectedSortKeys: string[],
+  defaultSortKey: string,
+  hasExplicitSortInQuery: boolean,
+): string[] {
+  if (hasExplicitSortInQuery) {
+    return selectedSortKeys
+  }
+
+  if (selectedSortKeys.length <= 1) {
+    return selectedSortKeys
+  }
+
+  if (!selectedSortKeys.includes(defaultSortKey)) {
+    return selectedSortKeys
+  }
+
+  return selectedSortKeys.filter(sortKey => sortKey !== defaultSortKey)
 }


### PR DESCRIPTION
- Closes https://github.com/chaotic-art/planning/issues/30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-select sorting enabled: users can now apply multiple sort criteria simultaneously when browsing NFT collections and items, providing more flexible filtering options.

* **Refactor**
  * Restructured sort handling system to support multiple sort keys instead of single-key selection, improving query construction and filtering logic throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<img width="400"  alt="CleanShot 2026-02-22 at 19 19 45@2x" src="https://github.com/user-attachments/assets/14f6ec0c-26a1-4d48-a27d-184ef65f27de" />
