### PR TITLE
fix: wrap fetchOdaCollection with try and log serializable error

### DIFF
--- a/app/pages/[chain]/drops/[slug].vue
+++ b/app/pages/[chain]/drops/[slug].vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { AssetHubChain } from '~/plugins/sdk.client'
+import { t } from 'try'
 import { fetchOdaCollection } from '~/services/oda'
 
 const dropStore = useDropStore()
@@ -11,7 +12,12 @@ onUnmounted(() => dropStore.reset())
 const { params } = useRoute()
 
 const dropData = await $fetch('/api/genart/list', { query: { alias: params.slug?.toString() ?? '' } })
-const collectionData = await fetchOdaCollection(params.chain?.toString() as AssetHubChain, dropData?.data[0]?.collection ?? '')
+const [ok, err, collectionDataResult] = await t(fetchOdaCollection(params.chain?.toString() as AssetHubChain, dropData?.data[0]?.collection ?? ''))
+const collectionData = ok ? collectionDataResult : { metadata: undefined, claimed: undefined }
+if (!ok) {
+  const errMessage = err instanceof Error ? err.message : String(err)
+  console.error('Error fetching ODA collection', errMessage)
+}
 const drop = {
   ...dropData,
   metadata: {


### PR DESCRIPTION
## Summary
Use `t()` from package `try` for `fetchOdaCollection` on the drops slug page and avoid Nuxt dev server serialization errors.

## Changes
- Wrap `fetchOdaCollection` with `t()` from `try` for safe error handling
- Fallback to empty `metadata` / `claimed` when the ODA fetch fails (e.g. 503)
- Log `err.message` (or `String(err)`) instead of the Error object so Nuxt dev server logs can be stringified without DevalueError

## Context
- ODA collection fetch can fail (e.g. 503); page should not crash
- `console.error(..., err)` with an Error object triggered: `DevalueError: Cannot stringify arbitrary non-POJOs` in Nuxt dev server logs

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for collection data retrieval with graceful fallback behavior and error logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->