### PR TITLE
fix: wrap fetchOdaToken in gallery detail with try for error handling

### DIFF
--- a/app/pages/[chain]/gallery/[token].vue
+++ b/app/pages/[chain]/gallery/[token].vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { AssetHubChain } from '~/plugins/sdk.client'
+import { t } from 'try'
 import { fetchOdaToken } from '~/services/oda'
 
 const CONTAINER_ID = 'nft-img-container'
@@ -30,7 +31,12 @@ const {
   fetchRarity: true,
 })
 
-const odaTokenData = await fetchOdaToken(chainPrefix.value, safeCollectionId.value, safeTokenId.value)
+const [ok, err, odaTokenDataResult] = await t(fetchOdaToken(chainPrefix.value, safeCollectionId.value, safeTokenId.value))
+const odaTokenData = ok ? odaTokenDataResult : { metadata: null, price: null, owner: null }
+if (!ok) {
+  const errMessage = err instanceof Error ? err.message : String(err)
+  console.error('Error fetching ODA token', errMessage)
+}
 const item = {
   ...odaTokenData,
   metadata: {
@@ -47,7 +53,7 @@ useSeoMeta({
 defineOgImage({
   component: 'Gallery',
   props: {
-    title: item.metadata.name,
+    title: item.metadata?.name,
     image: item.metadata?.image,
     network: chainSpec[chainPrefix.value].name,
     symbol: chainSpec[chainPrefix.value].tokenSymbol,


### PR DESCRIPTION
Wraps `fetchOdaToken` on the gallery detail page with `t` from the `try` package so the page does not crash when the ODA API fails.

- Import `t` from `try`
- Use fallback `{ metadata: null, price: null, owner: null }` on fetch failure
- Log errors with `console.error`
- Add optional chaining on `defineOgImage` props for safe fallback

Aligns with the pattern already used on the drops detail page.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Token gallery now gracefully handles data fetch failures with appropriate fallback values instead of crashing
* Improved error messaging to better identify when token data retrieval fails
* Fixed potential runtime errors when token metadata or images are unavailable through enhanced data access patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->