### PR TITLE
fix: resolve mint/collect art flow for drops

### DIFF
--- a/app/composables/drop/useGenerativeDropMint.ts
+++ b/app/composables/drop/useGenerativeDropMint.ts
@@ -1,4 +1,4 @@
-export function updateGenartMetadata() {
+export function updateGenartMetadata(isChaoticOwner = true) {
   const { drop } = useDrop()
   const { toMintNFTs, mintingSession } = storeToRefs(useDropStore())
 
@@ -9,6 +9,7 @@ export function updateGenartMetadata() {
         chain: drop.value.chain,
         collection: drop.value.collection,
         nft: item.nft.toString(),
+        isChaoticOwner,
       },
     })
 

--- a/app/composables/onchain/useNextItemId.ts
+++ b/app/composables/onchain/useNextItemId.ts
@@ -1,0 +1,25 @@
+import type { AssetHubChain } from '~/plugins/sdk.client'
+import { CHAOTIC_MINTER } from '~/utils/support'
+
+export function useNextItemId() {
+  const { $sdk } = useNuxtApp()
+  const isChaoticOwner = ref(true)
+
+  async function getNextItemId(chain: AssetHubChain, collectionId: number): Promise<number> {
+    const api = $sdk(chain).api
+    await api.compatibilityToken
+
+    const [entries, ownerQuery] = await Promise.all([
+      api.query.Nfts.Item.getEntries(collectionId),
+      api.query.Nfts.Collection.getValue(collectionId),
+    ])
+
+    const owner = ownerQuery?.owner.toString()
+    isChaoticOwner.value = owner === CHAOTIC_MINTER
+    const itemIds = entries.map(item => Number(item.keyArgs[1]))
+
+    return Math.max(0, ...itemIds) + 1
+  }
+
+  return { getNextItemId, isChaoticOwner }
+}

--- a/app/i18n/locales/en.json
+++ b/app/i18n/locales/en.json
@@ -53,6 +53,7 @@
     "generativeArtDrops": "Generative Art Drops",
     "pastDrops": "Past Art Drops",
     "mintDropError": "Error encountered, please retry. {0}",
+    "mintDropAlreadyExists": "This item was already minted by someone else. Please refresh the page and try again.",
     "youSuccessfullyClaimedNft": "You successfully minted {0} NFT",
     "amountMintedSuccessfully": "{0} NFTs minted successfully",
     "artBy": "{0} By",

--- a/server/api/genart/update-metadata.post.ts
+++ b/server/api/genart/update-metadata.post.ts
@@ -1,4 +1,4 @@
-import { object, string } from 'valibot'
+import { boolean, object, optional, string } from 'valibot'
 import { GENART_WORKERS_URL, vValidateBody } from '~~/server/utils/endpoint'
 
 // Valibot schema for updateMetadata request body
@@ -6,14 +6,18 @@ const UpdateMetadataSchema = object({
   chain: string(),
   collection: string(),
   nft: string(),
+  isChaoticOwner: optional(boolean()),
 })
 
 export default defineEventHandler(async (event) => {
   const validatedBody = await vValidateBody(event, UpdateMetadataSchema)
 
-  const response = await $fetch(`${GENART_WORKERS_URL}/drops/update-metadata`, {
+  const { isChaoticOwner = true, ...body } = validatedBody
+  const path = isChaoticOwner ? 'drops/update-metadata' : 'drops/update-metadata-old'
+
+  const response = await $fetch(`${GENART_WORKERS_URL}/${path}`, {
     method: 'POST',
-    body: validatedBody,
+    body,
   })
 
   return response


### PR DESCRIPTION
## Summary
Fixes the error encountered when trying to mint/collect art on Chaotic (reported in the screenshot from the user).

## Changes
- **Add `useNextItemId` composable** – onchain resolution of the next item ID for drops
- **Update drop mint composables** – `useDropMint`, `useGenerativeDropMint`, `useDropMassmint` to use the new flow
- **Update genart metadata API** – `server/api/genart/update-metadata.post.ts`
- **i18n** – updated strings in `en.json`

## Related
Closes #815

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added detection and clearer error messaging when attempting to mint items that were already minted by another user.
  * Enhanced minting operations with improved owner verification.

* **Bug Fixes**
  * Improved token ID generation for batch minting operations, now using deterministic sequential assignment instead of random generation.
  * Enhanced error handling for minting transaction failures with more specific error detection and user-friendly messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->