### PR TITLE
fix(explore): filter sidebar not sticky on scroll 

### DIFF
--- a/app/components/common/CollapsibleSidebar.vue
+++ b/app/components/common/CollapsibleSidebar.vue
@@ -62,12 +62,12 @@ const isFixed = computed(() => hasScrolledPastTarget.value && fitsInViewport.val
 
     <aside
       ref="sidebarRef"
-      class="h-fit overflow-hidden relative z-10"
+      class="h-fit overflow-hidden"
       :class="{
         'bg-background-muted border border-border rounded-xl': !isCollapsed,
         'border-transparent bg-transparent rounded-none pointer-events-none': isCollapsed,
         'sticky top-4': !sticky,
-        'fixed top-[100px]': isFixed,
+        'fixed top-[100px] z-10': isFixed,
       }"
       :style="{
         width: isCollapsed ? collapsedWidth : expandedWidth,


### PR DESCRIPTION
<img width="3266" height="1995" alt="image" src="https://github.com/user-attachments/assets/5019694d-f51c-4b2a-98f3-3eb7d18fef5b" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved sidebar stacking order to ensure correct display when pinned to the viewport, preventing overlap with other page elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->