### PR TITLE
fix(drops): default drop card image to placeholder

### DIFF
--- a/app/components/common/ImageMedia.vue
+++ b/app/components/common/ImageMedia.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+const props = withDefaults(defineProps<{
+  src?: string
+  alt?: string
+  fallbackSrc?: string
+}>(), {
+  src: '',
+  alt: '',
+  fallbackSrc: '/placeholder.jpg',
+})
+
+const resolvedSrc = computed(() => props.src || props.fallbackSrc)
+
+function handleError(event: Event) {
+  const image = event.target as HTMLImageElement
+
+  if (image.src.endsWith(props.fallbackSrc)) {
+    return
+  }
+
+  image.src = props.fallbackSrc
+}
+</script>
+
+<template>
+  <img
+    :src="resolvedSrc"
+    :alt="alt"
+    v-bind="$attrs"
+    @error="handleError"
+  >
+</template>

--- a/app/components/drop/DropCard.vue
+++ b/app/components/drop/DropCard.vue
@@ -2,6 +2,7 @@
 import type { DropItem } from '@/types'
 import type { GenartDropItem } from '~/types/genart'
 import { useMintedDropsStore } from '@/stores/dropsMinted'
+import ImageMedia from '~/components/common/ImageMedia.vue'
 import { getDropAttributes, isTBA } from './utils'
 
 const props = defineProps<{
@@ -42,11 +43,11 @@ onBeforeMount(async () => {
       </div>
     </div>
 
-    <img
+    <ImageMedia
       :src="sanitizeIpfsUrl(formattedDrop?.image) || '/placeholder.jpg'"
       :alt="formattedDrop?.name || drop.alias"
       class="aspect-square w-full object-cover"
-    >
+    />
 
     <div class="p-3 md:p-4">
       <p class="font-bold text-base md:text-lg mb-1 md:mb-2 line-clamp-2">


### PR DESCRIPTION
- Closes https://github.com/chaotic-art/app/issues/823
- https://github.com/chaotic-art/planning/issues/33

<img width="400"  alt="CleanShot 2026-03-01 at 15 17 46@2x" src="https://github.com/user-attachments/assets/290a9251-0615-4c10-b471-5d5144e0bd9b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Images now gracefully fall back to a placeholder when the primary image is missing or fails to load.

* **Bug Fixes**
  * Replaced fragile image rendering with a more robust approach to prevent broken image displays.

* **Accessibility**
  * Alt text now falls back to a meaningful label when the primary name is unavailable, improving screen-reader output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->