### PR TITLE
feat(search): add debounce on search input

### DIFF
--- a/app/components/common/NftsToolbar.vue
+++ b/app/components/common/NftsToolbar.vue
@@ -109,6 +109,11 @@ function updateQueryState(updates: Partial<QueryState>) {
   queryState.value = nextState
 }
 
+const { input: searchInput, onInput: handleSearchUpdate } = useDebouncedSyncedInput(
+  computed(() => queryState.value.search),
+  search => updateQueryState({ search }),
+)
+
 function computeQueryVariables(state: QueryState) {
   const selectedSortKeys = state.sortKeys
   const orderBy = buildOrderBy(selectedSortKeys)
@@ -160,11 +165,11 @@ watch(() => queryState.value, (newValue) => {
     />
 
     <UInput
-      :model-value="queryState.search"
+      :model-value="searchInput"
       placeholder="Search NFTs..."
       :class="props.stickySearchOnly ? STICKY_MOBILE_TOOLBAR_SEARCH_CLASS : 'w-48'"
       icon="i-heroicons-magnifying-glass"
-      @update:model-value="updateQueryState({ search: $event })"
+      @update:model-value="handleSearchUpdate($event)"
     />
 
     <template v-if="!props.stickySearchOnly">

--- a/app/components/profile/tabs/ProfileCollectionsList.vue
+++ b/app/components/profile/tabs/ProfileCollectionsList.vue
@@ -41,6 +41,11 @@ const queryState = computed({
   },
 })
 
+const { input: searchInput, onInput: handleSearchUpdate } = useDebouncedSyncedInput(
+  computed(() => queryState.value.search),
+  search => queryState.value = { ...queryState.value, search },
+)
+
 const queryVariables = computed(() => {
   const keywordFilter = buildKeywordClause(queryState.value.search)
 
@@ -58,11 +63,11 @@ const queryVariables = computed(() => {
   <div>
     <div class="flex items-center gap-2 mt-4">
       <UInput
-        :model-value="queryState.search"
+        :model-value="searchInput"
         placeholder="Search collections..."
         class="w-48"
         icon="i-heroicons-magnifying-glass"
-        @update:model-value="queryState = { ...queryState, search: $event }"
+        @update:model-value="handleSearchUpdate($event)"
       />
       <USelectMenu
         :model-value="queryState.sort"

--- a/app/components/trade/overviewModal/TokenSearchInput.vue
+++ b/app/components/trade/overviewModal/TokenSearchInput.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { ExploreNftsData } from '~/graphql/queries/explore'
+import { useDebounceFn } from '@vueuse/core'
 import { exploreNfts } from '~/graphql/queries/explore'
 
 const props = defineProps<{
@@ -47,6 +48,8 @@ async function onSearch(searchKey: string = '') {
   }))
 }
 
+const debouncedSearch = useDebounceFn((searchKey: string = '') => onSearch(searchKey), 300)
+
 onBeforeMount(onSearch)
 </script>
 
@@ -57,7 +60,7 @@ onBeforeMount(onSearch)
     open-on-focus
     size="lg"
     placeholder="Search tokens"
-    @update:search-term="onSearch"
+    @update:search-term="debouncedSearch"
     @change="() => {
       if (input?.value) {
         $emit('select', input.value)

--- a/app/composables/useDebouncedSyncedInput.ts
+++ b/app/composables/useDebouncedSyncedInput.ts
@@ -1,0 +1,35 @@
+import { watchDebounced } from '@vueuse/core'
+
+interface UseDebouncedSyncedInputOptions {
+  debounce?: number
+}
+
+export function useDebouncedSyncedInput(
+  source: Readonly<Ref<string>>,
+  onDebouncedChange: (value: string) => void,
+  options: UseDebouncedSyncedInputOptions = {},
+) {
+  const { debounce = 300 } = options
+  const input = ref(source.value)
+
+  function onInput(value: string) {
+    input.value = value
+  }
+
+  watch(source, (value) => {
+    if (value !== input.value) {
+      input.value = value
+    }
+  })
+
+  watchDebounced(input, (value) => {
+    if (value !== source.value) {
+      onDebouncedChange(value)
+    }
+  }, { debounce })
+
+  return {
+    input,
+    onInput,
+  }
+}

--- a/app/pages/[chain]/explore/collectibles.vue
+++ b/app/pages/[chain]/explore/collectibles.vue
@@ -53,6 +53,11 @@ const queryState = computed({
   },
 })
 
+const { input: searchInput, onInput: handleSearchUpdate } = useDebouncedSyncedInput(
+  computed(() => queryState.value.search),
+  search => queryState.value = { ...queryState.value, search },
+)
+
 const queryVariables = computed(() => {
   const keywordFilter = buildKeywordClause(queryState.value.search)
 
@@ -79,11 +84,11 @@ const gridKey = computed(() => `${queryVariables.value.orderBy.join(',')}::${que
           />
 
           <UInput
-            :model-value="queryState.search"
+            :model-value="searchInput"
             placeholder="Search collections..."
             :class="isFixed && isMobileViewport ? STICKY_MOBILE_TOOLBAR_SEARCH_CLASS : 'w-48'"
             icon="i-heroicons-magnifying-glass"
-            @update:model-value="queryState = { ...queryState, search: $event }"
+            @update:model-value="handleSearchUpdate($event)"
           />
 
           <USelectMenu


### PR DESCRIPTION
### What happened

we did not have debounce for search inputs across the app 
- https://github.com/chaotic-art/planning/issues/33

https://github.com/user-attachments/assets/2cc82038-2288-46d0-807b-220e1589852a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized search input responsiveness across collectibles, NFTs, and profile collections features with intelligent input debouncing, reducing unnecessary operations during typing while maintaining search accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->