### PR TITLE
fix(drops): add loading skeletons for title minted and price

### DIFF
--- a/app/components/drop/DropCard.vue
+++ b/app/components/drop/DropCard.vue
@@ -18,6 +18,7 @@ const hasDropData = computed(() => formattedDrop.value !== undefined)
 const shouldShowDrop = computed(() =>
   isDropLoading.value
   || props.showMinted
+  || (!isDropLoading.value && !hasDropData.value)
   || (hasDropData.value && !formattedDrop.value?.isMintedOut),
 )
 const isUnlimited = computed(() => formattedDrop.value?.max && formattedDrop.value.max >= Number.MAX_SAFE_INTEGER)


### PR DESCRIPTION
## Linked Issue
- https://github.com/chaotic-art/planning/issues/33

## Overview
- Added loading skeletons for DropCard (title, minted, and price) to improve perceived loading UX.
- Fixed invalid HTML structure in DropCard (nested links), which was causing layout jump/splitting during hydration.
- Improved loading/error handling so cards exit loading state correctly and show sensible fallback values when data is unavailable.

## Before / After
| Before | After |
|---|---|
| <img width="300" alt="Before DropCard loader state" src="https://github.com/user-attachments/assets/c9c9484b-4b60-42c4-9e97-7896253ab1a9" /> | <img width="300" alt="After DropCard loader state" src="https://github.com/user-attachments/assets/d469c6e0-1a85-4220-ac8b-db6fdbe1290d" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Loading skeletons for drop cards: placeholders for title, minted progress, and price; alias used as fallback name.
  * Card links restructured so media links are nested appropriately without changing visible behavior.

* **Bug Fixes**
  * Explicit loading state to prevent flicker and stale content.
  * Improved error handling: partial data cleared on failure and loading indicators reliably stop.
  * Sold-out status applied only after successful data retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
