### PR TITLE
ref(sitemap): include only `ahp` drops

### DIFF
--- a/server/api/__sitemap__/drops.ts
+++ b/server/api/__sitemap__/drops.ts
@@ -5,7 +5,7 @@ import type { GenartDropItem } from '~/types/genart'
 import { $fetch } from 'ofetch'
 
 import { GENART_WORKERS_URL } from '~~/server/utils/endpoint'
-import { createSitemapUrl, dedupeSitemapUrls, getErrorMessage, SITEMAP_CHAINS } from '~~/server/utils/sitemap'
+import { createSitemapUrl, dedupeSitemapUrls, DROPS_SITEMAP_CHAINS, getErrorMessage } from '~~/server/utils/sitemap'
 
 interface GenArtDropsResponse {
   data?: GenartDropItem[]
@@ -36,7 +36,7 @@ async function fetchDropUrlsForChain(chain: SitemapChain): Promise<SitemapUrl[]>
 
 export default defineSitemapEventHandler(async () => {
   const urls = await Promise.all(
-    SITEMAP_CHAINS.map(async (chain) => {
+    DROPS_SITEMAP_CHAINS.map(async (chain) => {
       try {
         return await fetchDropUrlsForChain(chain)
       }

--- a/server/utils/sitemap/index.ts
+++ b/server/utils/sitemap/index.ts
@@ -3,6 +3,7 @@ import type { SitemapUrl } from '#sitemap/types'
 import type { SitemapChain } from './graphql'
 
 export const SITEMAP_CHAINS: SitemapChain[] = ['ahp', 'ahk']
+export const DROPS_SITEMAP_CHAINS: SitemapChain[] = ['ahp']
 
 export function createSitemapUrl(loc: string, lastmod?: string): SitemapUrl | null {
   if (!loc.startsWith('/')) {


### PR DESCRIPTION

- remove `ahk` drops from being included in sitemap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated sitemap generation for drops functionality to use a specialized configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->