### PR TITLE
fix: show collection creator and info when ODA fails

### DIFF
--- a/app/components/collection/CollectionHeader.vue
+++ b/app/components/collection/CollectionHeader.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { SupportedChain } from '~/plugins/sdk.client'
+import type { AssetHubChain } from '~/plugins/sdk.client'
 import type { OnchainCollection } from '~/services/oda'
 import { getSubscanAccountUrl } from '~/utils/format/address'
 import { sanitizeIpfsUrl, toOriginalContentUrl } from '~/utils/ipfs'
@@ -9,7 +9,7 @@ const props = withDefaults(
   defineProps<{
     collection: OnchainCollection | null
     collectionId: string
-    chain: SupportedChain
+    chain: AssetHubChain
     /** Optional override for owner (e.g. drops creator). Falls back to collection.owner */
     creator?: string
     /** Optional drop alias for "View Drop" button */
@@ -38,8 +38,33 @@ const bannerUrl = computed(() => {
   return raw ? toOriginalContentUrl(sanitizeIpfsUrl(raw)) : ''
 })
 
-const ownerAddress = computed(
+const ownerFromProps = computed(
   () => props.creator || props.collection?.owner,
+)
+
+// Fallback: when ODA/drops fail, fetch collection owner from chain so creator + Subscan always show
+const ownerFromChain = ref<string | null>(null)
+onMounted(async () => {
+  if (ownerFromProps.value || !props.collectionId)
+    return
+  const collectionId = Number(props.collectionId)
+  if (Number.isNaN(collectionId))
+    return
+  try {
+    const { $sdk } = useNuxtApp()
+    const api = $sdk(props.chain).api
+    const collection = await api.query.Nfts.Collection.getValue(collectionId)
+    if (collection?.owner) {
+      ownerFromChain.value = collection.owner.toString()
+    }
+  }
+  catch {
+    // ignore
+  }
+})
+
+const ownerAddress = computed(
+  () => ownerFromProps.value || ownerFromChain.value,
 )
 </script>
 

--- a/app/components/gallery/GalleryDetails.vue
+++ b/app/components/gallery/GalleryDetails.vue
@@ -133,8 +133,8 @@ const actionItems = computed<DropdownMenuItem[]>(() => {
 <template>
   <div class="space-y-6">
     <div>
-      <!-- Collection Information -->
-      <div v-if="collection" class="flex items-center gap-2">
+      <!-- Collection Information (always show; use fallback when ODA collection fails) -->
+      <div class="flex items-center gap-2">
         <NuxtLink
           :to="`/${chain}/collection/${collectionId || ''}`"
           class="font-medium transition-colors flex items-center gap-2 text-blue-500 dark:text-blue-400 hover:text-blue-600 dark:hover:text-blue-500"
@@ -142,7 +142,7 @@ const actionItems = computed<DropdownMenuItem[]>(() => {
           <!-- Collection Image -->
           <div class="size-6 rounded-full overflow-hidden bg-muted flex shrink-0 items-center">
             <img
-              v-if="collection.metadata?.image"
+              v-if="collection?.metadata?.image"
               :src="sanitizeIpfsUrl(collection.metadata.image)"
               :alt="collection.metadata?.name || 'Collection'"
               class="w-full h-full object-cover"
@@ -153,7 +153,7 @@ const actionItems = computed<DropdownMenuItem[]>(() => {
               class="size-4 text-muted-foreground m-auto"
             />
           </div>
-          {{ collection.metadata?.name || `Collection ${collectionId || ''}` }}
+          {{ collection?.metadata?.name || `Collection ${collectionId || ''}` }}
         </NuxtLink>
       </div>
 

--- a/app/composables/useToken.ts
+++ b/app/composables/useToken.ts
@@ -78,6 +78,23 @@ export function useToken(props: {
       collectionCreator.value = collection.value?.owner ?? null
       queryPrice.value = token.value?.price ?? null
 
+      // When ODA collection fails, fall back to genart then on-chain for collection creator
+      if (!collectionCreator.value) {
+        const [genartOk, _, genartRes] = await t($fetch<{ data: Array<{ creator?: string }> }>('/api/genart/list', {
+          query: { collection: props.collectionId.toString() },
+        }))
+        if (genartOk && genartRes?.data?.[0]?.creator) {
+          collectionCreator.value = genartRes.data[0].creator
+        }
+      }
+      if (!collectionCreator.value) {
+        const { api } = $sdk(props.chain)
+        const collectionOnChain = await api.query.Nfts.Collection.getValue(props.collectionId).catch(() => null)
+        if (collectionOnChain?.owner) {
+          collectionCreator.value = collectionOnChain.owner.toString()
+        }
+      }
+
       const tokenRarityData = rarityData?.data.token
       const rarityTotalItems = normalizeRarityTotalItems(collectionData?.supply)
 

--- a/app/pages/[chain]/collection/[collection_id].vue
+++ b/app/pages/[chain]/collection/[collection_id].vue
@@ -2,10 +2,10 @@
 import type { LocationQueryRaw } from 'vue-router'
 import type { SelectedTrait } from '@/components/trait/types'
 import type { AssetHubChain } from '~/plugins/sdk.client'
-import { CHAINS } from '@kodadot1/static'
 import { TradeTypes } from '@/components/trade/types'
 import { fetchOdaCollection } from '~/services/oda'
 import { normalizeRarityTotalItems } from '~/types/rarity'
+import { chainSpec } from '~/utils/chain'
 
 const availableTabs = ['items', 'offers', 'swaps', 'traits', 'analytics'] as const
 type CollectionTab = typeof availableTabs[number]
@@ -72,12 +72,12 @@ const chain = computed(() => chainPrefix as AssetHubChain)
 const { data } = await useLazyAsyncData(
   `collection:${chain.value}:${collection_id}`,
   async () => {
-    const [collection, drops] = await Promise.all([
-      fetchOdaCollection(chain.value, collection_id?.toString() ?? ''),
+    const [collectionResult, drops] = await Promise.all([
+      fetchOdaCollection(chain.value, collection_id?.toString() ?? '').catch(() => null),
       $fetch('/api/genart/list', { query: { collection: collection_id?.toString() ?? '' } }),
     ])
 
-    return { collection, drops }
+    return { collection: collectionResult ?? null, drops }
   },
 )
 
@@ -173,7 +173,7 @@ function handleSelectedTraitsUpdate(traits: SelectedTrait[]) {
 definePageMeta({
   validate: async (route) => {
     const { chain } = route.params
-    return typeof chain === 'string' && chain in CHAINS
+    return typeof chain === 'string' && chain in chainSpec
   },
 })
 


### PR DESCRIPTION
Fixes #844

## Summary
When the ODA collection API errors (e.g. [issue #844](https://github.com/chaotic-art/app/issues/844)), the collection and gallery detail pages should still show collection creator and collection information by falling back to other sources.

## Changes

### Collection page (`[chain]/collection/[collection_id]`)
- Catch ODA fetch failure so the page still loads with drops data; `collection` is `null` when ODA fails.
- Use `chainSpec` for route `validate` instead of `@kodadot1/static` CHAINS.

### Gallery detail (useToken + GalleryDetails)
- **useToken**: If ODA collection has no owner, fall back to genart (`/api/genart/list` by collection) for creator; if still missing, query on-chain `Nfts.Collection` for owner so `collectionCreator` is set.
- **GalleryDetails**: Always show the collection info block (link + name or "Collection #id"); when creator is unknown, show fallback "–" instead of endless skeleton.

### Collection page header (CollectionHeader)
- When `creator` and `collection.owner` are both missing, fetch collection owner from chain (`api.query.Nfts.Collection`) in `onMounted` so creator + Subscan button still appear.
- Narrow `chain` prop type to `AssetHubChain` so `api.query.Nfts` is type-safe (relay chains have no Nfts pallet).