### PR TITLE
feat(collection): add `activity` tab

### DIFF
--- a/app/components/profile/tabs/profileActivity/ProfileActivity.vue
+++ b/app/components/profile/tabs/profileActivity/ProfileActivity.vue
@@ -1,14 +1,13 @@
 <script setup lang="ts">
 import type { EventInteraction } from './types'
 import { sortBy } from 'lodash'
-import { allEventsByProfile } from '~/graphql/queries/profiles'
+import { allEvents } from '~/graphql/queries/profiles'
 
 const props = defineProps<{
-  address: string
+  address?: string
+  collectionId?: string
 }>()
 const emit = defineEmits(['totalCountChange'])
-
-const filters = ['sale', 'buy', 'mint', 'transfer', 'list']
 
 const route = useRoute()
 const router = useRouter()
@@ -16,8 +15,13 @@ const { $apolloClient } = useNuxtApp()
 const loading = ref(true)
 const events = ref<EventInteraction[]>([])
 
+const isProfileScope = computed(() => Boolean(props.address))
+const filters = computed(() => isProfileScope.value
+  ? ['sale', 'buy', 'mint', 'transfer', 'list']
+  : ['sale', 'mint', 'transfer', 'list'])
+
 const activeFilters = computed(() =>
-  filters.filter(queryParam => route.query[queryParam] === 'true'),
+  filters.value.filter(queryParam => route.query[queryParam] === 'true'),
 )
 
 const interactionToFilterMap = {
@@ -27,9 +31,37 @@ const interactionToFilterMap = {
   SEND: 'transfer',
 }
 
+const scopeId = computed(() => props.address || props.collectionId || '')
+const where = computed(() => {
+  if (props.address) {
+    return {
+      OR: [
+        { caller_eq: props.address },
+        { currentOwner_eq: props.address },
+      ],
+    }
+  }
+
+  if (props.collectionId) {
+    return {
+      nft: {
+        collection: {
+          id_eq: props.collectionId,
+        },
+      },
+    }
+  }
+
+  return undefined
+})
+
 const filteredEvents = computed(() =>
   events.value.filter(({ interaction, caller }) => {
     if (interaction === 'BUY') {
+      if (!isProfileScope.value) {
+        return activeFilters.value.includes('sale')
+      }
+
       return activeFilters.value.includes(caller === props.address ? 'buy' : 'sale')
     }
     return activeFilters.value.includes(interactionToFilterMap[interaction as keyof typeof interactionToFilterMap])
@@ -40,7 +72,7 @@ function selectAll() {
   router.replace({
     query: {
       ...route.query,
-      ...filters.reduce((acc, filter) => {
+      ...filters.value.reduce((acc, filter) => {
         Object.assign(acc, { [filter]: true })
         return acc
       }, {}),
@@ -50,9 +82,9 @@ function selectAll() {
 
 async function fetchProfileActivity() {
   const response = await $apolloClient.query({
-    query: allEventsByProfile,
+    query: allEvents,
     variables: {
-      id: props.address,
+      where: where.value,
     },
   })
 
@@ -61,12 +93,16 @@ async function fetchProfileActivity() {
 }
 
 onMounted(async () => {
+  if (!scopeId.value) {
+    return
+  }
+
   if (!activeFilters.value.length) {
     router.replace({
       query: {
         ...route.query,
-        buy: String(true),
         sale: String(true),
+        ...(isProfileScope.value ? { buy: String(true) } : {}),
       },
     })
   }
@@ -79,7 +115,7 @@ onMounted(async () => {
 
 <template>
   <div class="my-4">
-    <ProfileActivityTable :loading="loading" :events="filteredEvents" :address>
+    <ProfileActivityTable :loading="loading" :events="filteredEvents" :address="address" :distinguish-buy-and-sell="isProfileScope">
       <div class="flex gap-3">
         <UButton
           variant="ghost"

--- a/app/components/profile/tabs/profileActivity/ProfileActivityTable.vue
+++ b/app/components/profile/tabs/profileActivity/ProfileActivityTable.vue
@@ -7,7 +7,8 @@ import { interactionNameMap } from './utils'
 
 const props = defineProps<{
   events: EventInteraction[]
-  address: string
+  address?: string
+  distinguishBuyAndSell?: boolean
   loading?: boolean
 }>()
 
@@ -104,7 +105,7 @@ function createTable(): void {
         event.to = ''
         break
       case Interaction.BUY:
-        if (newEvent.caller !== props.address) {
+        if (!props.distinguishBuyAndSell || newEvent.caller !== props.address) {
           event.type = 'SELL'
         }
         event.from = newEvent.currentOwner
@@ -219,8 +220,8 @@ watch(() => props.events, () => {
       <template #type-cell="{ row }">
         <EventTag
           :interaction="row.original.type"
-          :interaction-name="(interactionNameMap({ distinguishBuyAndSell: true }) as Record<string, string>)[row.original.type] || ''"
-          distinguish-buy-and-sell
+          :interaction-name="(interactionNameMap({ distinguishBuyAndSell: props.distinguishBuyAndSell ?? true }) as Record<string, string>)[row.original.type] || ''"
+          :distinguish-buy-and-sell="props.distinguishBuyAndSell ?? true"
         />
       </template>
 

--- a/app/components/profile/tabs/profileActivity/types.ts
+++ b/app/components/profile/tabs/profileActivity/types.ts
@@ -1,6 +1,6 @@
-import type { AllEventsByProfileData } from '~/graphql/queries/profiles'
+import type { AllEventsData } from '~/graphql/queries/profiles'
 
-export type EventInteraction = AllEventsByProfileData['events'][number]
+export type EventInteraction = AllEventsData['events'][number]
 
 export const Interaction = {
   ACCEPT: 'ACCEPT',

--- a/app/components/profile/tabs/profileActivity/utils.ts
+++ b/app/components/profile/tabs/profileActivity/utils.ts
@@ -25,6 +25,7 @@ export function interactionNameMap({ distinguishBuyAndSell }: MappingOptions = d
     MINT: 'Mint',
     SEND: 'Transfer',
     Offer: 'Offer',
+    SELL: 'Sale',
   }
 
   if (distinguishBuyAndSell) {

--- a/app/graphql/queries/profiles.ts
+++ b/app/graphql/queries/profiles.ts
@@ -1,9 +1,9 @@
 import type { ResultOf } from '../client'
 import { graphql } from '../client'
 
-export const allEventsByProfile = graphql(`
-    query allEventsByProfile($id: String) {
-      events(where: { caller_eq: $id, OR: { currentOwner_eq: $id } }) {
+export const allEvents = graphql(`
+    query allEvents($where: EventWhereInput) {
+      events(where: $where) {
         meta
         interaction
         blockNumber
@@ -31,4 +31,4 @@ export const allEventsByProfile = graphql(`
     }
 `)
 
-export type AllEventsByProfileData = ResultOf<typeof allEventsByProfile>
+export type AllEventsData = ResultOf<typeof allEvents>

--- a/app/pages/[chain]/collection/[collection_id].vue
+++ b/app/pages/[chain]/collection/[collection_id].vue
@@ -7,7 +7,7 @@ import { TradeTypes } from '@/components/trade/types'
 import { fetchOdaCollection } from '~/services/oda'
 import { normalizeRarityTotalItems } from '~/types/rarity'
 
-const availableTabs = ['items', 'offers', 'swaps', 'traits', 'analytics'] as const
+const availableTabs = ['items', 'activity', 'offers', 'swaps', 'traits', 'analytics'] as const
 type CollectionTab = typeof availableTabs[number]
 
 const route = useRoute()
@@ -29,6 +29,12 @@ const tabsItems = computed(() => [
     name: 'Items',
     slot: 'items',
     value: 'items',
+  },
+  {
+    label: 'Activity',
+    name: 'Activity',
+    slot: 'activity',
+    value: 'activity',
   },
   {
     label: 'Offers',
@@ -253,6 +259,9 @@ defineOgImageComponent('Frame', {
               />
             </div>
           </ExploreFilters>
+        </template>
+        <template #activity>
+          <ProfileActivity :collection-id="collection_id?.toString() ?? ''" />
         </template>
         <template #offers>
           <CollectionTrades :trade-type="TradeTypes.Offer" />


### PR DESCRIPTION
- https://github.com/chaotic-art/planning/issues/33

<img width="3234" height="3690" alt="CleanShot 2026-03-11 at 19 56 59@2x" src="https://github.com/user-attachments/assets/cc3d9399-503a-497e-9993-d5a1385b32bb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Activity tab to collection pages, displaying event history including mints, listings, and sales
  * Activity filtering now supports flexible scoping for both profile and collection-based views
  * Improved event labeling to clearly distinguish buying and selling transactions in activity feeds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->