### PR TITLE
feat: collection edit on studio details page

### DIFF
--- a/app/components/studio/StudioCollectionDetails.vue
+++ b/app/components/studio/StudioCollectionDetails.vue
@@ -1,0 +1,236 @@
+<script setup lang="ts">
+import type { OnchainCollection } from '~/services/oda'
+import { useCollectionEditForm } from '~/composables/create/useCollectionEditForm'
+import { sanitizeIpfsUrl, toOriginalContentUrl } from '~/utils/ipfs'
+
+const props = defineProps<{
+  collectionId: string
+  collection: OnchainCollection | null | undefined
+}>()
+
+const {
+  state,
+  logoFile,
+  bannerFile,
+  isWalletConnected,
+  isInitialized,
+  validate,
+  onSubmit,
+} = useCollectionEditForm(
+  toRef(props, 'collectionId'),
+  toRef(props, 'collection'),
+)
+
+const logoPreviewUrl = computed(() => {
+  if (logoFile.value) {
+    return URL.createObjectURL(logoFile.value)
+  }
+  const raw = props.collection?.metadata?.image
+  return raw ? toOriginalContentUrl(sanitizeIpfsUrl(raw)) : ''
+})
+
+const bannerPreviewUrl = computed(() => {
+  if (bannerFile.value) {
+    return URL.createObjectURL(bannerFile.value)
+  }
+  const raw = props.collection?.metadata?.banner || props.collection?.metadata?.image
+  return raw ? toOriginalContentUrl(sanitizeIpfsUrl(raw)) : ''
+})
+
+const submitButtonText = computed(() => {
+  if (!isWalletConnected.value) {
+    return 'Connect Wallet to Update'
+  }
+  return 'Update Collection'
+})
+</script>
+
+<template>
+  <div class="">
+    <div class="mb-8">
+      <h1 class="text-3xl font-bold text-gray-900 dark:text-white mb-2">
+        Collection Details
+      </h1>
+      <p class="text-gray-600 dark:text-gray-400">
+        Edit your collection information and visuals. Changes are stored on-chain.
+      </p>
+    </div>
+
+    <UCard class="relative">
+      <template #header>
+        <h2 class="text-xl font-semibold text-gray-900 dark:text-white">
+          Collection Info
+        </h2>
+      </template>
+
+      <div v-if="!collection && !isInitialized" class="flex justify-center py-12">
+        <USkeleton class="h-64 w-full rounded-lg" />
+      </div>
+
+      <UForm
+        v-else
+        :state="state"
+        :validate="(formState) => validate(formState)"
+        class="space-y-6"
+        @submit="onSubmit"
+      >
+        <UFormField
+          name="name"
+          label="Name"
+          required
+          help="This will be the name of your collection"
+        >
+          <UInput
+            v-model="state.name"
+            placeholder="My Awesome Collection"
+            class="w-full"
+          />
+        </UFormField>
+
+        <UFormField
+          name="description"
+          label="Description"
+          required
+          help="Describe your collection and what makes it unique"
+        >
+          <div class="space-y-1">
+            <UTextarea
+              v-model="state.description"
+              placeholder="Tell people about your collection..."
+              :rows="4"
+              maxlength="500"
+              class="w-full"
+            />
+            <div class="flex items-center justify-between gap-1.5 text-xs text-gray-500 dark:text-gray-400">
+              <div class="flex items-center gap-1.5 text-xs">
+                <UIcon name="i-heroicons-document-text" class="w-3.5 h-3.5 shrink-0" />
+                Supports markdown formatting.
+              </div>
+              <div class="text-xs">
+                {{ state.description.length }} / 500
+              </div>
+            </div>
+          </div>
+        </UFormField>
+
+        <UFormField
+          name="logo"
+          label="Logo"
+          help="Recommended: 400x400px, max 5MB. Leave empty to keep current."
+        >
+          <UFileUpload
+            v-slot="{ open }"
+            v-model="logoFile"
+            accept="image/*"
+            native
+            class="block"
+          >
+            <button
+              type="button"
+              class="group relative w-20 h-20 shrink-0 rounded-lg overflow-hidden bg-muted border border-default flex items-center justify-center hover:border-gray-400 dark:hover:border-gray-500 transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
+              @click="() => open()"
+            >
+              <img
+                v-if="logoPreviewUrl"
+                :src="logoPreviewUrl"
+                alt="Collection logo"
+                class="w-full h-full object-cover"
+              >
+              <div
+                v-if="logoPreviewUrl"
+                class="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 transition-opacity group-hover:opacity-100"
+                aria-hidden="true"
+              >
+                <UIcon name="i-heroicons-arrow-path" class="w-7 h-7 text-white" />
+              </div>
+              <div
+                v-if="!logoPreviewUrl"
+                class="flex flex-col items-center gap-1 text-gray-400"
+              >
+                <UIcon name="i-heroicons-arrow-up-tray" class="w-6 h-6" />
+                <span class="text-xs">Upload</span>
+              </div>
+            </button>
+          </UFileUpload>
+        </UFormField>
+
+        <UFormField
+          class="max-w-4xl"
+          name="banner"
+          label="Banner"
+          help="Recommended: 1200x400px, max 10MB. Leave empty to keep current."
+        >
+          <UFileUpload
+            v-slot="{ open }"
+            v-model="bannerFile"
+            accept="image/*"
+            native
+            class="block w-full"
+          >
+            <button
+              type="button"
+              class="group relative w-full aspect-3/1 min-h-28 rounded-lg overflow-hidden bg-muted border border-default flex items-center justify-center hover:border-gray-400 dark:hover:border-gray-500 transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
+              @click="() => open()"
+            >
+              <img
+                v-if="bannerPreviewUrl"
+                :src="bannerPreviewUrl"
+                alt="Collection banner"
+                class="w-full h-full object-cover"
+              >
+              <div
+                v-if="bannerPreviewUrl"
+                class="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 transition-opacity group-hover:opacity-100"
+                aria-hidden="true"
+              >
+                <UIcon name="i-heroicons-arrow-path" class="w-12 h-12 text-white" />
+              </div>
+              <div
+                v-if="!bannerPreviewUrl"
+                class="flex flex-col items-center gap-2 text-gray-400"
+              >
+                <UIcon name="i-heroicons-arrow-up-tray" class="w-10 h-10" />
+                <span class="text-sm">Upload banner</span>
+              </div>
+            </button>
+          </UFileUpload>
+        </UFormField>
+
+        <div class="space-y-4">
+          <h3 class="text-lg font-semibold text-gray-900 dark:text-white">
+            Royalties
+          </h3>
+
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <UFormField
+              name="royalties"
+              label="Creator Royalties (%)"
+              help="Percentage you earn from secondary sales"
+            >
+              <UInput
+                v-model.number="state.royalties"
+                type="number"
+                min="0"
+                max="100"
+                step="0.1"
+                placeholder="0"
+                class="w-full"
+              />
+            </UFormField>
+          </div>
+        </div>
+
+        <div class="flex justify-end pt-4 border-t border-gray-200 dark:border-gray-700">
+          <UButton
+            type="submit"
+            size="xl"
+            :disabled="!isWalletConnected"
+            :variant="isWalletConnected ? 'solid' : 'soft'"
+          >
+            {{ submitButtonText }}
+          </UButton>
+        </div>
+      </UForm>
+    </UCard>
+  </div>
+</template>

--- a/app/composables/create/useCollectionEditForm.ts
+++ b/app/composables/create/useCollectionEditForm.ts
@@ -1,0 +1,191 @@
+import type { FormError, FormSubmitEvent } from '@nuxt/ui'
+import type { AssetHubChain } from '~/plugins/sdk.client'
+import type { OnchainCollection } from '~/services/oda'
+import { useQueryClient } from '@tanstack/vue-query'
+import { useNftPallets } from '~/composables/onchain/useNftPallets'
+import { refreshOdaCollection } from '~/services/oda'
+import { pinDirectory, pinJson } from '~/services/storage'
+
+export function useCollectionEditForm(
+  collectionId: Ref<string>,
+  collection: Ref<OnchainCollection | null | undefined>,
+) {
+  const { currentChain } = useChain()
+  const { updateCollection, collectionRoyalties } = useNftPallets()
+  const { open, onSuccess } = useTransactionModal()
+  const queryClient = useQueryClient()
+
+  const { getConnectedSubAccount } = storeToRefs(useWalletStore())
+  const isWalletConnected = computed(() => Boolean(getConnectedSubAccount.value?.address))
+
+  const state = reactive({
+    name: '',
+    description: '',
+    royalties: 0,
+  })
+
+  const logoFile = ref<File | null>(null)
+  const bannerFile = ref<File | null>(null)
+
+  const currentRoyalty = ref<number | null>(null)
+  const isInitialized = ref(false)
+
+  const chain = computed(() => currentChain.value as AssetHubChain)
+
+  watch(
+    () => collectionId.value,
+    () => {
+      isInitialized.value = false
+    },
+  )
+
+  watch(
+    [collection, () => collectionId.value],
+    async ([col]) => {
+      const c = col as OnchainCollection | null | undefined
+      if (!c?.metadata || !collectionId.value || isInitialized.value) {
+        return
+      }
+
+      state.name = c.metadata.name ?? ''
+      state.description = c.metadata.description ?? ''
+
+      try {
+        const royalty = await collectionRoyalties(chain.value, Number(collectionId.value))
+        currentRoyalty.value = royalty?.amount ?? null
+        state.royalties = royalty?.amount ?? 0
+      }
+      catch {
+        state.royalties = 0
+        currentRoyalty.value = null
+      }
+
+      isInitialized.value = true
+    },
+    { immediate: true },
+  )
+
+  function validate(formState: Partial<unknown>): FormError[] {
+    const state = formState as { name: string, description: string, royalties: number }
+    const errors: FormError[] = []
+    if (!state.name?.trim()) {
+      errors.push({ name: 'name', message: 'Collection name is required' })
+    }
+    if (!state.description?.trim()) {
+      errors.push({ name: 'description', message: 'Description is required' })
+    }
+    if (Number(state.royalties) < 0) {
+      errors.push({ name: 'royalties', message: 'Royalties must be 0% or higher' })
+    }
+    if (Number(state.royalties) > 100) {
+      errors.push({ name: 'royalties', message: 'Royalties cannot exceed 100%' })
+    }
+    if (logoFile.value) {
+      const maxLogoSize = 5 * 1024 * 1024
+      if (logoFile.value.size > maxLogoSize) {
+        errors.push({ name: 'logo', message: 'Logo file size must be less than 5MB' })
+      }
+      if (!logoFile.value.type.startsWith('image/')) {
+        errors.push({ name: 'logo', message: 'Logo must be an image file' })
+      }
+    }
+    if (bannerFile.value) {
+      const maxBannerSize = 10 * 1024 * 1024
+      if (bannerFile.value.size > maxBannerSize) {
+        errors.push({ name: 'banner', message: 'Banner file size must be less than 10MB' })
+      }
+      if (!bannerFile.value.type.startsWith('image/')) {
+        errors.push({ name: 'banner', message: 'Banner must be an image file' })
+      }
+    }
+    return errors
+  }
+
+  async function prepareMetadata(): Promise<string> {
+    const c = collection.value
+    const existingImage = c?.metadata?.image
+    const existingBanner = c?.metadata?.banner
+
+    let image: string
+    let banner: string | undefined
+
+    const filesToPin: File[] = []
+    if (logoFile.value) {
+      filesToPin.push(logoFile.value)
+    }
+    if (bannerFile.value) {
+      filesToPin.push(bannerFile.value)
+    }
+
+    if (filesToPin.length > 0) {
+      const cidImages = await pinDirectory(filesToPin)
+      image = logoFile.value
+        ? `ipfs://${cidImages}/${logoFile.value.name}`
+        : (existingImage ?? '')
+      banner = bannerFile.value
+        ? `ipfs://${cidImages}/${bannerFile.value.name}`
+        : existingBanner
+    }
+    else {
+      image = existingImage ?? ''
+      banner = existingBanner
+    }
+
+    const metadata: Record<string, string> = {
+      name: state.name,
+      description: state.description,
+      image,
+      external_url: 'https://chaotic.art',
+    }
+    if (banner) {
+      metadata.banner = banner
+    }
+
+    const cid = await pinJson(metadata)
+    return `ipfs://${cid}`
+  }
+
+  onSuccess('collection', () => {
+    successMessage('Collection updated successfully')
+    refreshOdaCollection(chain.value, collectionId.value)
+    queryClient.invalidateQueries({ queryKey: ['odaCollection', collectionId] })
+  })
+
+  async function onSubmit(_event: FormSubmitEvent<typeof state>) {
+    if (!isWalletConnected.value) {
+      return
+    }
+
+    const id = Number(collectionId.value)
+    if (Number.isNaN(id)) {
+      return
+    }
+
+    try {
+      open.value = true
+      const metadataUri = await prepareMetadata()
+      const royaltyPayload = state.royalties !== (currentRoyalty.value ?? 0) ? state.royalties : undefined
+
+      updateCollection({
+        chain: chain.value,
+        collectionId: id,
+        type: 'submit',
+        metadataUri,
+        royalty: royaltyPayload,
+      })
+    }
+    catch (err) {
+      console.error('Error updating collection:', err)
+    }
+  }
+
+  return {
+    state,
+    logoFile,
+    bannerFile,
+    isWalletConnected,
+    isInitialized,
+    validate,
+    onSubmit,
+  }
+}

--- a/app/composables/onchain/useNftPallets.ts
+++ b/app/composables/onchain/useNftPallets.ts
@@ -278,6 +278,99 @@ export function useNftPallets() {
     })
   }
 
+  interface UpdateCollectionParams {
+    chain: AssetHubChain
+    collectionId: number
+    type: TxType
+    metadataUri?: string
+    royalty?: number
+  }
+
+  async function updateCollection({
+    chain,
+    collectionId,
+    type,
+    metadataUri,
+    royalty,
+  }: UpdateCollectionParams) {
+    if (!getConnectedSubAccount.value?.address) {
+      throw new Error('No address found')
+    }
+
+    const api = $sdk(chain).api
+    await api.compatibilityToken
+
+    const calls = []
+
+    if (metadataUri) {
+      calls.push(
+        api.tx.Nfts.set_collection_metadata({
+          collection: collectionId,
+          data: Binary.fromText(metadataUri),
+        }).decodedCall,
+      )
+    }
+
+    if (royalty !== undefined) {
+      calls.push(
+        api.tx.Nfts.set_attribute({
+          collection: collectionId,
+          maybe_item: undefined,
+          namespace: { type: 'CollectionOwner', value: undefined },
+          key: Binary.fromText('royalty'),
+          value: Binary.fromText(royalty.toString()),
+        }).decodedCall,
+      )
+      calls.push(
+        api.tx.Nfts.set_attribute({
+          collection: collectionId,
+          maybe_item: undefined,
+          namespace: { type: 'CollectionOwner', value: undefined },
+          key: Binary.fromText('recipient'),
+          value: Binary.fromText(getConnectedSubAccount.value.address),
+        }).decodedCall,
+      )
+    }
+
+    if (calls.length === 0) {
+      return type === 'estimate' ? 0n : undefined
+    }
+
+    const transaction = api.tx.Utility.batch_all({ calls })
+
+    if (type === 'estimate') {
+      const estimatedFees = await transaction.getEstimatedFees(getConnectedSubAccount.value.address)
+      return estimatedFees
+    }
+
+    const signer = await getConnectedSubAccount.value.signer
+    if (!signer) {
+      throw new Error('No signer found')
+    }
+
+    transaction.signSubmitAndWatch(signer).subscribe({
+      next: (event) => {
+        status.value = event.type
+        if (event.type === 'txBestBlocksState' && event.found) {
+          hash.value = event.block.hash.toString()
+          result.value = {
+            type: 'collection',
+            id: collectionId.toString(),
+            name: '',
+            description: '',
+            image: '',
+            hash: hash.value,
+            prefix: chain,
+          }
+        }
+      },
+      error: (err) => {
+        console.error('error', err)
+        error.value = err
+      },
+    })
+  }
+
   async function userBalance(chain: SupportedChain) {
     if (!getConnectedSubAccount.value?.address) {
       // throw new Error('No address found')
@@ -1205,6 +1298,7 @@ export function useNftPallets() {
 
   return {
     createCollection,
+    updateCollection,
     mintNft,
     listNfts,
     userCollection,

--- a/app/layouts/studio-collection.vue
+++ b/app/layouts/studio-collection.vue
@@ -52,7 +52,7 @@ function handleDestroyCollection() {
 // TODO: Add relevant nav items pages
 const navItems: StudioNavItem[] = [
   { id: 'preview' as const, label: 'Preview', icon: 'i-heroicons:eye' },
-  // { id: 'details' as const, label: 'Details', icon: 'i-heroicons-cog-6-tooth' },
+  { id: 'details' as const, label: 'Details', icon: 'i-heroicons-cog-6-tooth' },
   // { id: 'items' as const, label: 'Items', icon: 'i-heroicons-squares-2x2' },
 ]
 

--- a/app/pages/[chain]/studio/[collection_id]/[tab].vue
+++ b/app/pages/[chain]/studio/[collection_id]/[tab].vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import CollectionHeader from '~/components/collection/CollectionHeader.vue'
 import { isAssetHubChain } from '~/utils/chain'
 
 const validTabs = ['preview', 'details', 'items'] as const
@@ -30,6 +31,11 @@ const { collection } = useOdaCollection(collectionId)
       :collection="collection ?? null"
       :collection-id="collectionId"
       :chain="currentChain"
+    />
+    <StudioCollectionDetails
+      v-else-if="tab === 'details'"
+      :collection-id="collectionId"
+      :collection="collection ?? null"
     />
     <p
       v-else


### PR DESCRIPTION
closes https://github.com/chaotic-art/planning/issues/19

<img width="3810" height="1930" alt="image" src="https://github.com/user-attachments/assets/1a6f0c83-2f9c-4750-9212-e864948ca14d" />
<img width="3784" height="1270" alt="image" src="https://github.com/user-attachments/assets/e25612b0-797b-4bf7-b94f-f3dbe7187e92" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a collection details editor in the studio interface, enabling users to update on-chain collection metadata including name, description, logo, and banner images.
  * Added creator royalties management with support for precision up to 0.1%.
  * Enabled the Details tab in the collection studio navigation for managing collection information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->