### PR TITLE
fix(drops): container padding

### DIFF
--- a/app/pages/[chain]/drops/index.vue
+++ b/app/pages/[chain]/drops/index.vue
@@ -12,7 +12,7 @@ const { data: drops } = await useFetch('/api/genart/list', {
 </script>
 
 <template>
-  <UContainer>
+  <UContainer class="pb-16">
     <h1 class="text-2xl md:text-4xl font-medium font-serif italic mb-6 md:mb-10 text-center md:text-left px-4 md:px-0">
       {{ $t('drop.generativeArtDrops') }}
     </h1>


### PR DESCRIPTION
## What happened 
- https://github.com/chaotic-art/planning/issues/33

<img width="3698" height="1950" alt="CleanShot 2026-03-13 at 11 13 08@2x" src="https://github.com/user-attachments/assets/15d1651c-6b48-4545-81f3-a0d256c5bb4b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted bottom spacing on the drops page layout for improved visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->