### PR TITLE
styles(traits): align dark table surfaces

### DIFF
--- a/app/components/gallery/GalleryAdditionalContent.client.vue
+++ b/app/components/gallery/GalleryAdditionalContent.client.vue
@@ -153,7 +153,7 @@ onMounted(async () => {
               />
             </template>
             <template #properties>
-              <div class="bg-background rounded-xl border border-border overflow-hidden">
+              <div class="bg-white dark:bg-neutral-800 rounded-xl border border-neutral-200 dark:border-neutral-700 overflow-hidden">
                 <UTable
                   v-if="properties.length"
                   :data="properties"

--- a/app/components/trait/TraitOverview.vue
+++ b/app/components/trait/TraitOverview.vue
@@ -123,7 +123,7 @@ function exportToCsv() {
       <!-- Summary Cards and Controls -->
       <div class="space-y-4">
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="bg-background border border-border rounded-xl p-6">
+          <div class="bg-white dark:bg-neutral-800 rounded-xl border border-neutral-200 dark:border-neutral-700 p-6">
             <div class="text-sm text-muted-foreground mb-1">
               Total Traits
             </div>
@@ -132,7 +132,7 @@ function exportToCsv() {
             </div>
           </div>
 
-          <div class="bg-background border border-border rounded-xl p-6">
+          <div class="bg-white dark:bg-neutral-800 rounded-xl border border-neutral-200 dark:border-neutral-700 p-6">
             <div class="text-sm text-muted-foreground mb-1">
               Total Values
             </div>
@@ -142,7 +142,7 @@ function exportToCsv() {
           </div>
         </div>
 
-        <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 p-4 bg-background border border-border rounded-xl">
+        <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 p-4 bg-white dark:bg-neutral-800 rounded-xl border border-neutral-200 dark:border-neutral-700">
           <div class="flex flex-wrap items-center justify-between gap-2 w-full">
             <div class="flex flex-wrap items-center gap-2">
               <span class="text-sm font-medium text-muted-foreground">View Mode:</span>
@@ -200,7 +200,7 @@ function exportToCsv() {
             </span>
           </div>
 
-          <div class="bg-background rounded-xl border border-border overflow-hidden">
+          <div class="bg-white dark:bg-neutral-800 rounded-xl border border-neutral-200 dark:border-neutral-700 overflow-hidden">
             <UTable
               :data="traits"
               :columns="columns"
@@ -229,7 +229,7 @@ function exportToCsv() {
             </div>
           </div>
 
-          <div class="bg-background rounded-xl border border-border p-6">
+          <div class="bg-white dark:bg-neutral-800 rounded-xl border border-neutral-200 dark:border-neutral-700 p-6">
             <ClientOnly>
               <TraitDistributionChart
                 :trait-type="traitType"


### PR DESCRIPTION
### Issue



Gallery properties tab and collection traits dont follow same design 

- styles: updated colors to match other tabs design
- https://github.com/chaotic-art/planning/issues/33

<img width="1670" height="498" alt="CleanShot 2026-03-14 at 19 39 07@2x" src="https://github.com/user-attachments/assets/70e78745-6a4b-4e23-b76f-431d7016ae87" />

<img width="2806" height="1528" alt="CleanShot 2026-03-14 at 19 39 29@2x" src="https://github.com/user-attachments/assets/8da0ff2e-0fce-456f-870f-65675131d4f1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style

* Updated styling across gallery and trait overview components with improved dark mode support
* Enhanced theme-aware backgrounds and borders in properties panels, trait cards, control bars, tables, and chart containers for better visual consistency in both light and dark modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->