### PR TITLE
fix: clear selected items when leaving studio items page

### DIFF
--- a/app/components/studio/StudioCollectionItems.vue
+++ b/app/components/studio/StudioCollectionItems.vue
@@ -1,7 +1,13 @@
 <script setup lang="ts">
+import { useActionCartStore } from '@/stores/actionCart'
+
 const props = defineProps<{
   collectionId: string
 }>()
+const actionCartStore = useActionCartStore()
+onUnmounted(() => {
+  actionCartStore.clear()
+})
 </script>
 
 <template>


### PR DESCRIPTION
Bugfix: The batch action toolbar appeared on other tabs as well, after selecting a few nfts on the items page and switch tab.
<img width="3790" height="1714" alt="image" src="https://github.com/user-attachments/assets/bb927875-1207-4d94-8fb0-9db48270c6ec" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed improper state retention in the studio collection view by ensuring the action cart is properly cleared upon component unmount.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->