### PR TITLE
feat: traits search on studio trait page

### DIFF
--- a/app/components/studio/StudioCollectionTraits.vue
+++ b/app/components/studio/StudioCollectionTraits.vue
@@ -18,7 +18,7 @@ interface NftRow {
 }
 
 const props = defineProps<Props>()
-
+const search = ref('')
 const {
   loading,
   nftsList,
@@ -68,6 +68,20 @@ const rows = computed<NftRow[]>(() => {
   return base
 })
 
+const filteredRows = computed(() => {
+  const q = search.value.trim().toLowerCase()
+  if (!q) {
+    return rows.value
+  }
+
+  return rows.value.filter((r) => {
+    if (String(r.sn).includes(q) || r.name.toLowerCase().includes(q)) {
+      return true
+    }
+    return r.properties.some(p => p.trait.toLowerCase().includes(q) || p.value.toLowerCase().includes(q))
+  })
+})
+
 const columns = [
   {
     accessorKey: 'sn',
@@ -96,6 +110,14 @@ const columns = [
           Traits Overview
         </div>
       </div>
+
+      <UInput
+        v-model="search"
+        icon="i-heroicons-magnifying-glass"
+        placeholder="Search SN, name, or traits"
+        class="w-full sm:w-80"
+        aria-label="Search collection NFTs"
+      />
     </div>
 
     <div v-if="loading" class="flex items-center justify-center py-12">
@@ -115,7 +137,7 @@ const columns = [
     <div v-else class="space-y-4">
       <div class="rounded-xl border border-border bg-background overflow-hidden">
         <UTable
-          :data="rows"
+          :data="filteredRows"
           :columns="columns"
           class="w-full max-h-[80vh]"
           sticky


### PR DESCRIPTION
related to https://github.com/chaotic-art/planning/issues/22

<img width="3286" height="302" alt="image" src="https://github.com/user-attachments/assets/c81bd6a1-8d8f-4ca1-bce6-1219d5b26dc4" />
<img width="3280" height="852" alt="image" src="https://github.com/user-attachments/assets/61958e61-92a4-4186-ae4c-63995cef947f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search functionality to filter NFT collections in real-time
  * Users can search by serial number, name, or trait/value pairs
  * Search input integrated into the header area with live filtering results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->