### PR TITLE
feat: bulk trait assignment tools

### DIFF
--- a/app/components/studio/StudioCollectionTraits.vue
+++ b/app/components/studio/StudioCollectionTraits.vue
@@ -1,19 +1,37 @@
 <script setup lang="ts">
 import type { TableColumn } from '@nuxt/ui'
 import type { NftTraitsEditRow } from '~/components/studio/StudioCollectionTraitsEditSidebar.vue'
+import type { Property } from '~/composables/onchain/useNftPallets'
 import { h, resolveComponent } from 'vue'
+import {
+  bulkTraitRowMatchesQuery,
+  collectionTraitRowMatchesQuery,
+  csvIdsMissingFromCollection,
+  exportBulkTraitsCsv,
+  normalizeNftGraphqlAttributes,
+  normalizePropertiesForCompare,
+  parseBulkTraitsCsv,
+  parseSnFromNftEntityId,
+  propertiesEqual,
+} from '~/components/studio/utils'
+import { useNftPallets } from '~/composables/onchain/useNftPallets'
+import { fetchTokenMetadata } from '~/composables/useToken'
+import { pinJson } from '~/services/storage'
 import { sanitizeIpfsUrl } from '~/utils/ipfs'
 
 interface Props {
   collectionId: string
 }
 
-interface NftTraitProperty {
-  trait?: string
-  value: string
+interface BulkTraitRow extends NftTraitsEditRow {
+  nextProperties: Property[] | null
+  isChanged: boolean
 }
 
 const props = defineProps<Props>()
+const route = useRoute()
+const router = useRouter()
+const toast = useToast()
 const search = ref('')
 const {
   loading,
@@ -24,9 +42,17 @@ const {
 })
 
 const { onSuccess } = useTransactionModal()
+const { currentChain } = useChain()
+const { getItemMetadataUri, bulkUpdateItemsAttributes } = useNftPallets()
 
 const sidebarOpen = ref(false)
 const editingRow = ref<NftTraitsEditRow | null>(null)
+
+const bulkMode = ref(false)
+const pendingCsv = ref<Map<string, Property[]> | null>(null)
+const csvParseError = ref('')
+const csvInputRef = ref<HTMLInputElement | null>(null)
+const applyingBulk = ref(false)
 
 watch(sidebarOpen, (v) => {
   if (!v) {
@@ -34,41 +60,23 @@ watch(sidebarOpen, (v) => {
   }
 })
 
-function parseSn(id?: string) {
-  const parts = String(id ?? '').split('-')
-  const tokenId = Number(parts.at(-1))
-  return Number.isFinite(tokenId) ? tokenId : 0
-}
-
-function normalizeProperties(attrs?: NftTraitProperty[]) {
-  const out: Array<{ trait: string, value: string }> = []
-
-  ;(attrs ?? []).forEach((a) => {
-    const trait = a.trait?.trim()
-    const value = String(a.value ?? '').trim()
-    if (!trait || !value) {
-      return
-    }
-    out.push({ trait, value })
-  })
-
-  out.sort((a, b) => {
-    if (a.trait !== b.trait) {
-      return a.trait.localeCompare(b.trait)
-    }
-    return a.value.localeCompare(b.value)
-  })
-
-  return out
-}
+onMounted(() => {
+  if (route.query.bulk === '1') {
+    bulkMode.value = true
+    const q = { ...route.query }
+    delete q.bulk
+    router.replace({ query: q })
+  }
+})
 
 const rows = computed<NftTraitsEditRow[]>(() => {
   const base = (nftsList.value ?? []).map((nft) => {
     return {
-      sn: parseSn(nft.id),
+      id: nft.id ?? '',
+      sn: parseSnFromNftEntityId(nft.id),
       image: nft.meta?.image ?? null,
       name: (nft.name?.trim() || 'Untitled NFT'),
-      properties: normalizeProperties(nft.meta?.attributes as NftTraitProperty[] | undefined),
+      properties: normalizeNftGraphqlAttributes(nft.meta?.attributes),
     } satisfies NftTraitsEditRow
   })
 
@@ -76,27 +84,155 @@ const rows = computed<NftTraitsEditRow[]>(() => {
   return base
 })
 
-const filteredRows = computed(() => {
-  const q = search.value.trim().toLowerCase()
-  if (!q) {
-    return rows.value
-  }
+const filteredRows = computed(() =>
+  rows.value.filter(r => collectionTraitRowMatchesQuery(search.value, r)),
+)
 
-  return rows.value.filter((r) => {
-    if (String(r.sn).includes(q) || r.name.toLowerCase().includes(q)) {
-      return true
+const bulkTableRows = computed<BulkTraitRow[]>(() => {
+  const csv = pendingCsv.value
+  return rows.value.map((row) => {
+    if (!csv || !csv.has(row.id)) {
+      return { ...row, nextProperties: null, isChanged: false }
     }
-    return r.properties.some(p => p.trait.toLowerCase().includes(q) || p.value.toLowerCase().includes(q))
+    const next = normalizePropertiesForCompare(csv.get(row.id)!)
+    const current: Property[] = row.properties.map(p => ({ trait: p.trait, value: p.value }))
+    const isChanged = !propertiesEqual(current, next)
+    return { ...row, nextProperties: next, isChanged }
   })
 })
+
+const filteredBulkRows = computed(() =>
+  bulkTableRows.value.filter(r => bulkTraitRowMatchesQuery(search.value, r)),
+)
+
+const csvUnknownIds = computed(() => {
+  if (!pendingCsv.value) {
+    return [] as string[]
+  }
+  return csvIdsMissingFromCollection(
+    rows.value.map(r => r.id),
+    pendingCsv.value.keys(),
+  )
+})
+
+const changedBulkCount = computed(() => bulkTableRows.value.filter(r => r.isChanged).length)
 
 function openEditSidebar(row: NftTraitsEditRow) {
   editingRow.value = row
   sidebarOpen.value = true
 }
 
+function enterBulkMode() {
+  bulkMode.value = true
+  pendingCsv.value = null
+  csvParseError.value = ''
+}
+
+function exitBulkMode() {
+  bulkMode.value = false
+  pendingCsv.value = null
+  csvParseError.value = ''
+}
+
+function exportBulkCsv() {
+  const exportRows = rows.value.map(r => ({
+    id: r.id,
+    properties: r.properties.map(p => ({ trait: p.trait, value: p.value })),
+  }))
+  exportBulkTraitsCsv(exportRows, `collection-${props.collectionId}`)
+}
+
+function triggerCsvImport() {
+  csvInputRef.value?.click()
+}
+
+async function onCsvFile(e: Event) {
+  const input = e.target as HTMLInputElement
+  const file = input.files?.[0]
+  if (!file) {
+    return
+  }
+  csvParseError.value = ''
+  try {
+    const text = await file.text()
+    const parsed = parseBulkTraitsCsv(text)
+    if (!parsed.ok) {
+      csvParseError.value = parsed.error
+      pendingCsv.value = null
+      return
+    }
+    pendingCsv.value = parsed.data.byId
+  }
+  catch (err) {
+    console.error('Bulk traits CSV read failed:', err)
+    csvParseError.value = 'Could not read the CSV file.'
+    pendingCsv.value = null
+  }
+  finally {
+    input.value = ''
+  }
+}
+
+async function confirmBulkApply() {
+  const toApply = bulkTableRows.value.filter(r => r.isChanged)
+  if (toApply.length === 0) {
+    return
+  }
+
+  const chain = currentChain.value
+  const collectionId = Number(props.collectionId)
+  applyingBulk.value = true
+  try {
+    const items = await Promise.all(
+      toApply.map(async (row) => {
+        const currentUri = await getItemMetadataUri(chain, collectionId, row.sn)
+        const currentMeta = currentUri ? await fetchTokenMetadata(currentUri) : null
+        const nextProps = row.nextProperties ?? []
+        const attributesForMeta = nextProps.map(p => ({ trait_type: p.trait, value: p.value }))
+        const newMetadata = currentMeta
+          ? { ...currentMeta, attributes: attributesForMeta }
+          : {
+              name: row.name,
+              description: '',
+              image: row.image ?? undefined,
+              attributes: attributesForMeta,
+            }
+
+        const cid = await pinJson(newMetadata)
+        return {
+          itemId: row.sn,
+          properties: nextProps,
+          metadataUri: `ipfs://${cid}`,
+        }
+      }),
+    )
+
+    await bulkUpdateItemsAttributes({
+      chain,
+      collectionId,
+      items,
+    })
+  }
+  catch (err) {
+    console.error('Bulk traits apply failed:', err)
+    toast.add({
+      title: 'Bulk update failed',
+      description: err instanceof Error ? err.message : 'Unknown error',
+      color: 'error',
+    })
+  }
+  finally {
+    applyingBulk.value = false
+  }
+}
+
 onSuccess('update_attributes', () => {
   refetch()
+})
+
+onSuccess('bulk_update_attributes', () => {
+  refetch()
+  exitBulkMode()
 })
 
 const columns: TableColumn<NftTraitsEditRow>[] = [
@@ -132,6 +268,29 @@ const columns: TableColumn<NftTraitsEditRow>[] = [
       ]),
   },
 ]
+
+const bulkColumns: TableColumn<BulkTraitRow>[] = [
+  {
+    accessorKey: 'sn',
+    header: '#',
+  },
+  {
+    accessorKey: 'image',
+    header: 'Image',
+  },
+  {
+    accessorKey: 'name',
+    header: 'Name',
+  },
+  {
+    accessorKey: 'properties',
+    header: 'Properties',
+  },
+  {
+    accessorKey: 'nextProperties',
+    header: 'New properties',
+  },
+]
 </script>
 
 <template>
@@ -143,14 +302,102 @@ const columns: TableColumn<NftTraitsEditRow>[] = [
         </div>
       </div>
 
-      <UInput
-        v-model="search"
-        icon="i-heroicons-magnifying-glass"
-        placeholder="Search SN, name, or traits"
-        class="w-full sm:w-80"
-        aria-label="Search collection NFTs"
-      />
+      <div v-if="!bulkMode" class="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3 w-full sm:w-auto">
+        <UInput
+          v-model="search"
+          icon="i-heroicons-magnifying-glass"
+          placeholder="Search SN, name, or traits"
+          class="w-full sm:w-80"
+          aria-label="Search collection NFTs"
+        />
+        <UButton
+          variant="outline"
+          icon="i-heroicons-pencil-square"
+          class="shrink-0"
+          @click="enterBulkMode"
+        >
+          Bulk Edit
+        </UButton>
+      </div>
+
+      <div v-else class="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3 w-full sm:w-auto">
+        <UInput
+          v-model="search"
+          icon="i-heroicons-magnifying-glass"
+          placeholder="Search SN, name, or traits"
+          class="w-full sm:w-80"
+          aria-label="Search collection NFTs"
+        />
+        <UButton
+          variant="ghost"
+          color="neutral"
+          icon="i-heroicons-arrow-left"
+          class="shrink-0"
+          @click="exitBulkMode"
+        >
+          Back
+        </UButton>
+      </div>
     </div>
+
+    <div v-if="bulkMode" class="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
+      <UTooltip
+        text="Export this collection’s traits to CSV for editing."
+        :popper="{ placement: 'top' }"
+      >
+        <UButton
+          icon="i-heroicons-arrow-down-tray"
+          variant="outline"
+          :disabled="rows.length === 0"
+          @click="exportBulkCsv"
+        >
+          Export CSV
+        </UButton>
+      </UTooltip>
+      <input
+        ref="csvInputRef"
+        type="file"
+        accept=".csv,text/csv"
+        class="hidden"
+        aria-label="Upload traits CSV"
+        @change="onCsvFile"
+      >
+      <UTooltip
+        text="Upload your edited CSV. Properties column: trait:value;trait2:value2 (semicolon-separated pairs)."
+        :popper="{ placement: 'top' }"
+      >
+        <UButton
+          icon="i-heroicons-arrow-up-tray"
+          variant="outline"
+          :disabled="rows.length === 0"
+          @click="triggerCsvImport"
+        >
+          Upload CSV
+        </UButton>
+      </UTooltip>
+      <UButton
+        :disabled="changedBulkCount === 0 || applyingBulk"
+        :loading="applyingBulk"
+        @click="confirmBulkApply"
+      >
+        Confirm changes ({{ changedBulkCount }})
+      </UButton>
+    </div>
+
+    <UAlert
+      v-if="bulkMode && csvParseError"
+      color="error"
+      variant="soft"
+      :title="csvParseError"
+    />
+
+    <UAlert
+      v-if="bulkMode && csvUnknownIds.length > 0"
+      color="warning"
+      variant="soft"
+      title="These NFT ids from the CSV were not found in this collection:"
+      :description="csvUnknownIds.join(', ')"
+    />
 
     <div v-if="loading" class="flex items-center justify-center py-12">
       <UIcon name="i-heroicons-arrow-path" class="w-8 h-8 animate-spin text-muted" />
@@ -166,7 +413,7 @@ const columns: TableColumn<NftTraitsEditRow>[] = [
       </div>
     </div>
 
-    <div v-else class="space-y-4">
+    <div v-else-if="!bulkMode" class="space-y-4">
       <div class="rounded-xl border border-border bg-background overflow-hidden">
         <UTable
           :data="filteredRows"
@@ -198,6 +445,79 @@ const columns: TableColumn<NftTraitsEditRow>[] = [
                 <div
                   v-for="(p, idx) in row.original.properties"
                   :key="`${p.trait}-${p.value}-${idx}`"
+                  class="text-foreground"
+                >
+                  <span class="text-muted">{{ p.trait }}:</span>
+                  {{ ' ' }}{{ p.value }}
+                </div>
+              </div>
+            </div>
+          </template>
+        </UTable>
+      </div>
+    </div>
+
+    <div v-else class="space-y-4">
+      <div class="rounded-xl border border-border bg-background overflow-hidden">
+        <UTable
+          :data="filteredBulkRows"
+          :columns="bulkColumns"
+          class="w-full max-h-[80vh]"
+          sticky
+        >
+          <template #image-cell="{ row }">
+            <div class="py-2">
+              <img
+                v-if="row.original.image"
+                :src="sanitizeIpfsUrl(row.original.image)"
+                :alt="row.original.name"
+                class="w-14 h-14 aspect-square rounded-lg object-cover border border-border bg-muted"
+                loading="lazy"
+              >
+              <div v-else class="w-14 h-14 aspect-square rounded-lg border border-border bg-muted flex items-center justify-center">
+                <UIcon name="i-heroicons-photo" class="w-6 h-6 text-muted" />
+              </div>
+            </div>
+          </template>
+
+          <template #properties-cell="{ row }">
+            <div class="py-2 text-sm leading-5">
+              <div v-if="row.original.properties.length === 0" class="text-muted">
+                —
+              </div>
+              <div v-else class="space-y-0.5">
+                <div
+                  v-for="(p, idx) in row.original.properties"
+                  :key="`${p.trait}-${p.value}-${idx}`"
+                  class="text-foreground"
+                >
+                  <span class="text-muted">{{ p.trait }}:</span>
+                  {{ ' ' }}{{ p.value }}
+                </div>
+              </div>
+            </div>
+          </template>
+
+          <template #nextProperties-cell="{ row }">
+            <div class="py-2 text-sm leading-5 space-y-1">
+              <UBadge
+                v-if="row.original.isChanged"
+                color="warning"
+                variant="subtle"
+                size="xs"
+              >
+                Changed
+              </UBadge>
+              <div v-if="!row.original.nextProperties" class="text-muted">
+                —
+              </div>
+              <div v-else-if="row.original.nextProperties.length === 0" class="text-muted">
+                -
+              </div>
+              <div v-else class="space-y-0.5">
+                <div
+                  v-for="(p, idx) in row.original.nextProperties"
+                  :key="`new-${p.trait}-${p.value}-${idx}`"
                   class="text-foreground"
                 >
                   <span class="text-muted">{{ p.trait }}:</span>

--- a/app/components/studio/StudioCollectionTraitsEditSidebar.vue
+++ b/app/components/studio/StudioCollectionTraitsEditSidebar.vue
@@ -5,6 +5,7 @@ import { pinJson } from '~/services/storage'
 import { sanitizeIpfsUrl } from '~/utils/ipfs'
 
 export interface NftTraitsEditRow {
+  id: string
   sn: number
   image?: string | null
   name: string

--- a/app/components/studio/utils.ts
+++ b/app/components/studio/utils.ts
@@ -1,0 +1,218 @@
+import type { Property } from '~/composables/onchain/useNftPallets'
+
+const ATTRIBUTE_SEPARATOR = ';'
+const EXPECTED_HEADERS = ['id', 'properties'] as const
+
+export interface NftGraphqlTraitAttribute {
+  trait?: string
+  value: string
+}
+
+export function parseSnFromNftEntityId(id?: string): number {
+  const parts = String(id ?? '').split('-')
+  const tokenId = Number(parts.at(-1))
+  return Number.isFinite(tokenId) ? tokenId : 0
+}
+
+export function normalizeNftGraphqlAttributes(attrs?: NftGraphqlTraitAttribute[]): Property[] {
+  const out: Property[] = []
+
+  ;(attrs ?? []).forEach((a) => {
+    const trait = a.trait?.trim()
+    const value = String(a.value ?? '').trim()
+    if (!trait || !value) {
+      return
+    }
+    out.push({ trait, value })
+  })
+
+  out.sort((a, b) => {
+    if (a.trait !== b.trait) {
+      return a.trait.localeCompare(b.trait)
+    }
+    return a.value.localeCompare(b.value)
+  })
+
+  return out
+}
+
+export function collectionTraitRowMatchesQuery(
+  searchRaw: string,
+  row: { sn: number, name: string, properties: Property[] },
+): boolean {
+  const q = searchRaw.trim().toLowerCase()
+  if (!q) {
+    return true
+  }
+  if (String(row.sn).includes(q) || row.name.toLowerCase().includes(q)) {
+    return true
+  }
+  return row.properties.some(p => p.trait.toLowerCase().includes(q) || p.value.toLowerCase().includes(q))
+}
+
+export function bulkTraitRowMatchesQuery(
+  searchRaw: string,
+  row: {
+    sn: number
+    name: string
+    properties: Property[]
+    nextProperties: Property[] | null
+  },
+): boolean {
+  const q = searchRaw.trim().toLowerCase()
+  if (!q) {
+    return true
+  }
+  if (String(row.sn).includes(q) || row.name.toLowerCase().includes(q)) {
+    return true
+  }
+  if (row.properties.some(p => p.trait.toLowerCase().includes(q) || p.value.toLowerCase().includes(q))) {
+    return true
+  }
+  if (row.nextProperties?.some(p => p.trait.toLowerCase().includes(q) || p.value.toLowerCase().includes(q))) {
+    return true
+  }
+  return false
+}
+
+export function csvIdsMissingFromCollection(
+  collectionNftIds: Iterable<string>,
+  csvIds: Iterable<string>,
+): string[] {
+  const known = new Set(collectionNftIds)
+  return [...csvIds].filter(id => !known.has(id))
+}
+
+export function escapeCsvCell(value: string | number): string {
+  const s = String(value)
+  if (s.includes(',') || s.includes('"') || s.includes('\n')) {
+    return `"${s.replace(/"/g, '""')}"`
+  }
+  return s
+}
+
+/** properties format: `trait:value;trait2:value2` */
+export function parsePropertiesCell(value: string): Property[] {
+  const out: Property[] = []
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return out
+  }
+  trimmed.split(ATTRIBUTE_SEPARATOR).forEach((attr) => {
+    const idx = attr.indexOf(':')
+    if (idx === -1) {
+      return
+    }
+    const trait = attr.slice(0, idx).trim()
+    const val = attr.slice(idx + 1).trim()
+    if (trait && val) {
+      out.push({ trait, value: val })
+    }
+  })
+  return out
+}
+
+export function serializeProperties(props: Property[]): string {
+  return props.map(p => `${p.trait}:${p.value}`).join(';')
+}
+
+function parseCsvLine(line: string): string[] {
+  const result: string[] = []
+  let current = ''
+  let inQuotes = false
+  for (let i = 0; i < line.length; i++) {
+    const c = line[i]!
+    if (c === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"'
+        i++
+      }
+      else {
+        inQuotes = !inQuotes
+      }
+    }
+    else if (c === ',' && !inQuotes) {
+      result.push(current.trim())
+      current = ''
+    }
+    else {
+      current += c
+    }
+  }
+  result.push(current.trim())
+  return result
+}
+
+export interface ParsedBulkTraitsCsv {
+  byId: Map<string, Property[]>
+}
+
+export function parseBulkTraitsCsv(content: string): { ok: true, data: ParsedBulkTraitsCsv } | { ok: false, error: string } {
+  const text = content.replace(/^\uFEFF/, '').trim()
+  if (!text) {
+    return { ok: false, error: 'The file is empty.' }
+  }
+
+  const lines = text.split(/\r?\n/).filter(l => l.trim().length > 0)
+  if (lines.length < 2) {
+    return { ok: false, error: 'Expected a header row and at least one data row.' }
+  }
+
+  const headerCells = parseCsvLine(lines[0]!).map(h => h.trim().toLowerCase())
+  if (headerCells.length < 2) {
+    return { ok: false, error: 'Expected columns: id, properties' }
+  }
+
+  const idIdx = headerCells.indexOf('id')
+  const propIdx = headerCells.indexOf('properties')
+  if (idIdx === -1 || propIdx === -1) {
+    return { ok: false, error: `Header must include: ${EXPECTED_HEADERS.join(', ')}` }
+  }
+
+  const byId = new Map<string, Property[]>()
+  for (let i = 1; i < lines.length; i++) {
+    const cells = parseCsvLine(lines[i]!)
+    const id = cells[idIdx]?.trim()
+    if (!id) {
+      continue
+    }
+    const rawProps = cells[propIdx] ?? ''
+    byId.set(id, parsePropertiesCell(rawProps))
+  }
+
+  return { ok: true, data: { byId } }
+}
+
+export function exportBulkTraitsCsv(
+  rows: Array<{ id: string, properties: Property[] }>,
+  filenameBase: string,
+): void {
+  const header = 'id,properties'
+  const lines = [header, ...rows.map(r =>
+    [escapeCsvCell(r.id), escapeCsvCell(serializeProperties(r.properties))].join(','),
+  )]
+  const csv = lines.join('\n')
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `${filenameBase}-traits-bulk.csv`
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+export function normalizePropertiesForCompare(props: Property[]): Property[] {
+  return [...props]
+    .filter(p => p.trait.trim() && p.value.trim())
+    .map(p => ({ trait: p.trait.trim(), value: p.value.trim() }))
+    .sort((a, b) => (a.trait !== b.trait ? a.trait.localeCompare(b.trait) : a.value.localeCompare(b.value)))
+}
+
+export function propertiesEqual(a: Property[], b: Property[]): boolean {
+  const na = normalizePropertiesForCompare(a)
+  const nb = normalizePropertiesForCompare(b)
+  if (na.length !== nb.length) {
+    return false
+  }
+  return na.every((p, i) => p.trait === nb[i]!.trait && p.value === nb[i]!.value)
+}

--- a/app/components/trait/TraitOverview.vue
+++ b/app/components/trait/TraitOverview.vue
@@ -12,6 +12,15 @@ type ViewMode = 'table' | 'charts'
 
 const props = defineProps<Props>()
 
+const route = useRoute()
+const bulkEditStudioTo = computed(() => {
+  const chain = typeof route.params.chain === 'string' ? route.params.chain : ''
+  if (!chain || !props.collectionId) {
+    return ''
+  }
+  return `/${chain}/studio/${props.collectionId}/traits?bulk=1`
+})
+
 const { attributesRarityMaps, traitCounts, loading } = useCollectionAttributes({
   collectionId: computed(() => props.collectionId),
 })
@@ -158,13 +167,23 @@ function exportToCsv() {
                 </UButton>
               </div>
             </div>
-            <UButton
-              icon="i-heroicons-arrow-down-tray"
-              variant="outline"
-              @click="exportToCsv"
-            >
-              Export to CSV
-            </UButton>
+            <div class="flex flex-wrap items-center gap-2">
+              <UButton
+                v-if="bulkEditStudioTo"
+                :to="bulkEditStudioTo"
+                icon="i-heroicons-document-pencil"
+                variant="outline"
+              >
+                Bulk Edit
+              </UButton>
+              <UButton
+                icon="i-heroicons-arrow-down-tray"
+                variant="outline"
+                @click="exportToCsv"
+              >
+                Export to CSV
+              </UButton>
+            </div>
           </div>
 
           <div v-if="viewMode === 'charts'" class="flex items-center gap-2">

--- a/app/composables/onchain/useNftPallets.ts
+++ b/app/composables/onchain/useNftPallets.ts
@@ -158,6 +158,16 @@ interface CreateSwapParams {
   type?: TxType
 }
 
+interface BulkUpdateItemsAttributesParams {
+  chain: AssetHubChain
+  collectionId: number
+  items: Array<{
+    itemId: number
+    properties: Property[]
+    metadataUri: string
+  }>
+}
+
 export type SwapSurchargeDirection = 'Send' | 'Receive'
 
 export interface SwapSurcharge { amount: string, direction: SwapSurchargeDirection }
@@ -632,6 +642,73 @@ export function useNftPallets() {
       },
       error: (err) => {
         console.error('Update attributes error:', err)
+        error.value = err
+      },
+    })
+  }
+
+  async function bulkUpdateItemsAttributes({
+    chain,
+    collectionId,
+    items,
+  }: BulkUpdateItemsAttributesParams) {
+    if (items.length === 0) {
+      throw new Error('No updates to submit')
+    }
+
+    const { signer } = await getAccountSigner()
+    const api = $sdk(chain).api
+    const calls = [] as Parameters<typeof api.tx.Utility.batch_all>[0]['calls']
+
+    for (const item of items) {
+      const validProperties = item.properties.filter(p => p.trait.trim() && p.value.trim())
+      calls.push(
+        api.tx.Nfts.set_metadata({
+          collection: collectionId,
+          item: item.itemId,
+          data: Binary.fromText(item.metadataUri),
+        }).decodedCall,
+      )
+      validProperties.forEach((property) => {
+        calls.push(
+          api.tx.Nfts.set_attribute({
+            collection: collectionId,
+            maybe_item: item.itemId,
+            namespace: {
+              type: 'CollectionOwner',
+              value: undefined,
+            },
+            key: Binary.fromText(property.trait),
+            value: Binary.fromText(property.value),
+          }).decodedCall,
+        )
+      })
+    }
+
+    if (calls.length === 0) {
+      throw new Error('No updates to submit')
+    }
+
+    open.value = true
+    const transaction = api.tx.Utility.batch_all({ calls })
+
+    transaction.signSubmitAndWatch(signer).subscribe({
+      next: (event) => {
+        status.value = event.type
+
+        if (event.type === 'txBestBlocksState' && event.found) {
+          hash.value = event.txHash.toString()
+          result.value = {
+            type: 'bulk_update_attributes',
+            collectionId: String(collectionId),
+            itemIds: items.map(i => i.itemId),
+            hash: hash.value,
+            prefix: chain,
+          }
+        }
+      },
+      error: (err) => {
+        console.error('Bulk update attributes error:', err)
         error.value = err
       },
     })
@@ -1380,6 +1457,7 @@ export function useNftPallets() {
     mintNft,
     getItemMetadataUri,
     updateItemAttributes,
+    bulkUpdateItemsAttributes,
     listNfts,
     userCollection,
     userBalance,

--- a/app/composables/useTransactionModal.ts
+++ b/app/composables/useTransactionModal.ts
@@ -105,6 +105,14 @@ export interface UpdateAttributesTransactionResult {
   prefix: AssetHubChain
 }
 
+export interface BulkUpdateAttributesTransactionResult {
+  type: 'bulk_update_attributes'
+  collectionId: string
+  itemIds: number[]
+  hash: string
+  prefix: AssetHubChain
+}
+
 type TransactionResult
   = CollectionCategory
     | NftCategory
@@ -118,6 +126,7 @@ type TransactionResult
     | CreateSwapTransactionResult
     | DestroyCollectionTransactionResult
     | UpdateAttributesTransactionResult
+    | BulkUpdateAttributesTransactionResult
 
 // Transaction status progression:
 // 1. status.value = 'signed'


### PR DESCRIPTION
closes https://github.com/chaotic-art/planning/issues/22

<img width="1974" height="964" alt="image" src="https://github.com/user-attachments/assets/104c8c3b-2c77-4faa-8b11-14861fde23eb" />
<img width="2072" height="892" alt="image" src="https://github.com/user-attachments/assets/3298e1c7-ad95-47bc-a1b1-970e7f206028" />
<img width="1224" height="300" alt="image" src="https://github.com/user-attachments/assets/fd34538b-c33f-4f23-af68-00c05859a62e" />
<img width="1800" height="194" alt="image" src="https://github.com/user-attachments/assets/0d1da92f-940d-4df7-a48a-758924958941" />
<img width="1968" height="1740" alt="image" src="https://github.com/user-attachments/assets/a09f12d4-3fa6-434b-9dca-019453c13d7b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added bulk edit mode for collection traits, enabling users to import trait changes via CSV file.
  * Implemented CSV export functionality to download current collection traits for offline editing.
  * Added "Bulk Edit" button to collection trait overview for easy access to bulk operations.
  * Enabled batch application of trait updates across multiple NFTs in a single transaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->