### PR TITLE
fix(create): collection wrong ipfs image path

### DIFF
--- a/app/composables/create/useCollectionForm.ts
+++ b/app/composables/create/useCollectionForm.ts
@@ -144,7 +144,7 @@ export function useCollectionForm() {
     }
 
     const cidImages = await pinDirectory(filesToPin)
-    const image = `ipfs://${cidImages}/${logoFile.value?.name}`
+    const image = filesToPin.length === 1 ? `ipfs://${cidImages}` : `ipfs://${cidImages}/${logoFile.value?.name}`
     const banner = bannerFile.value ? `ipfs://${cidImages}/${bannerFile.value.name}` : undefined
 
     const metadata: any = {


### PR DESCRIPTION
### What happened 
- Closes #868

when uploading an image  using filebase ipos service if one file is provided the the image path is just the cid, we were assuming the cid always had the filename in the path which only happens if we also upload the banner

<img width="1824" height="298" alt="CleanShot 2026-03-24 at 18 16 40@2x" src="https://github.com/user-attachments/assets/afcdf597-d211-47f8-b0b3-611ec79dbaa4" />

the image was uploaded successfully [link](https://imagedelivery.net/Im3azVCMHMp2rDcvZOACIg/QmV9jTbo5XGDVNrfXKXtPhXTEvaDeeJE3YGxjwMtTcUp7o/public)

<img width="100" alt="image" src="https://github.com/user-attachments/assets/dba2ae4c-5fc7-49eb-b08e-fa56870fc108" />


### How to reproduce 
- go to collection create
- only upload logo 
- create collection 





### Proof 

<img width="3288" height="2016" alt="CleanShot 2026-03-24 at 18 10 11@2x" src="https://github.com/user-attachments/assets/8dc15e23-6b85-40e9-bc39-009cd2399220" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed image URI generation for collections to properly handle different pinning scenarios, ensuring collections display with correct image references regardless of the number of assets pinned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->